### PR TITLE
create schema context to encapsulate data for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/*
 !vendor/vendor.json
 example_playbooks/testing_playbook.az
 cli/azad
+cli/cli

--- a/conn/command_response.go
+++ b/conn/command_response.go
@@ -2,6 +2,12 @@ package conn
 
 import "bytes"
 
+// Response represent the stdout and stderr of a command over ssh
+type Response interface {
+	Stdout() string
+	Stderr() string
+}
+
 // CommandResponse wraps output from stdout and stderr
 type CommandResponse struct {
 	stdout *bytes.Buffer

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -4,7 +4,7 @@ import "bytes"
 
 type Conn interface {
 	ConnectTo(string) error
-	Run(Command) (CommandResponse, error)
+	Run(Command) (Response, error)
 	Close()
 }
 

--- a/conn/logger_ssh_conn.go
+++ b/conn/logger_ssh_conn.go
@@ -18,7 +18,7 @@ func (loggerSSHConn *LoggerSSHConn) ConnectTo(hostName string) error {
 }
 
 // Run output the command to logger.Debug
-func (loggerSSHConn *LoggerSSHConn) Run(command Command) (CommandResponse, error) {
+func (loggerSSHConn *LoggerSSHConn) Run(command Command) (Response, error) {
 	loggerSSHConn.Commands = append(loggerSSHConn.Commands, command)
 	logger.Debug("Running on %s", loggerSSHConn.ConnectedTo)
 	logger.Debug(command.generateFile())

--- a/conn/ssh_conn.go
+++ b/conn/ssh_conn.go
@@ -49,7 +49,7 @@ var now = func() int64 {
 // Returns the result of stdout and stderr in the command response
 // Returns an error if an ssh session cannot be created or
 // if the command has a non-zero exit code
-func (sshConn *SSHConn) Run(command Command) (CommandResponse, error) {
+func (sshConn *SSHConn) Run(command Command) (Response, error) {
 	ref := now()
 	writeCommandFile := fmt.Sprintf("echo '%s' > /tmp/azad.%d && chmod +x /tmp/azad.%d", command.generateFile(), ref, ref)
 	if _, err := sshConn.runOnClient(writeCommandFile); err != nil {
@@ -70,7 +70,7 @@ func (sshConn *SSHConn) Run(command Command) (CommandResponse, error) {
 	return commandResposne, err
 }
 
-func (sshConn SSHConn) runOnClient(command string) (CommandResponse, error) {
+func (sshConn SSHConn) runOnClient(command string) (Response, error) {
 	commandResposne := CommandResponse{
 		stdout: bytes.NewBuffer([]byte{}),
 		stderr: bytes.NewBuffer([]byte{}),

--- a/core/core.go
+++ b/core/core.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"plugin"
 
-	"github.com/pythonandchips/azad/conn"
-	"github.com/pythonandchips/azad/logger"
 	"github.com/pythonandchips/azad/schema"
 )
 
@@ -47,16 +45,13 @@ func getSchema() schema.Schema {
 	}
 }
 
-func runCommand(vars map[string]string, connection conn.Conn) error {
-	command := conn.Command{
+func runCommand(context schema.Context) error {
+	command := schema.Command{
 		Interpreter: "bash",
 		Command: []string{
-			vars["command"],
+			context.Get("command"),
 		},
 	}
-
-	commandResponse, err := connection.Run(command)
-	logger.Debug(commandResponse.Stdout())
-	logger.Debug(commandResponse.Stderr())
+	err := context.Run(command)
 	return err
 }

--- a/runner/run_playbook.go
+++ b/runner/run_playbook.go
@@ -97,7 +97,8 @@ func runTasks(tasks azad.Tasks, runners runners) error {
 
 func runTask(task azad.Task, taskSchema schema.Task, runner runner) error {
 	logger.Info("Applying %s:%s on %s", task.Type, task.Name, runner.Address)
-	err := taskSchema.Run(task.Attributes, runner.Conn)
+	context := schema.NewContext(task.Attributes, runner.Conn)
+	err := taskSchema.Run(context)
 	if err != nil {
 		logger.Error("Failed %s:%s on %s", task.Type, task.Name, runner.Address)
 		logger.Error("Error: %s", err)

--- a/schema/context.go
+++ b/schema/context.go
@@ -1,0 +1,50 @@
+package schema
+
+import (
+	"github.com/pythonandchips/azad/conn"
+)
+
+// NewContext create a new context for passing to a plugin to run a task
+func NewContext(vars map[string]string, conn conn.Conn) Context {
+	return Context{
+		vars: vars,
+		conn: conn,
+	}
+}
+
+// Context for task run. Main representation of data for task run
+type Context struct {
+	conn   conn.Conn
+	vars   map[string]string
+	env    map[string]string
+	stdout string
+	stderr string
+}
+
+// Run command against the ssh connection for the server
+func (context *Context) Run(command Command) error {
+	cmd := conn.Command{
+		Interpreter: command.Interpreter,
+		Command:     command.Command,
+		User:        command.User,
+	}
+	response, err := context.conn.Run(cmd)
+	context.stdout = response.Stdout()
+	context.stderr = response.Stderr()
+	return err
+}
+
+// Stdout retrieve the result of stdout sent by the last run
+func (context Context) Stdout() string {
+	return context.stdout
+}
+
+// Stderr retrieve the result of stdout sent by the last run
+func (context Context) Stderr() string {
+	return context.stderr
+}
+
+// Get the configuration value for the task
+func (context Context) Get(key string) string {
+	return context.vars[key]
+}

--- a/schema/context_test.go
+++ b/schema/context_test.go
@@ -1,0 +1,46 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextRun(t *testing.T) {
+	command := Command{
+		Interpreter: "bash",
+		Command:     []string{"pwd"},
+		User:        "root",
+	}
+	response := FakeResponse{
+		stdout: "stdout",
+		stderr: "stderr",
+	}
+	fakeConn := &FakeConn{response: response}
+	context := Context{
+		conn: fakeConn,
+		env: map[string]string{
+			"env": "dev",
+		},
+		vars: map[string]string{
+			"variable": "value",
+		},
+	}
+
+	context.Run(command)
+	t.Run("returns stdout form command", func(t *testing.T) {
+		assert.Equal(t, context.Stdout(), response.stdout)
+	})
+	t.Run("returns stderr form command", func(t *testing.T) {
+		assert.Equal(t, context.Stderr(), response.stderr)
+	})
+	t.Run("passes the command to be ran on connection", func(t *testing.T) {
+		assert.Equal(t, fakeConn.command.Interpreter, command.Interpreter)
+		assert.Equal(t, fakeConn.command.Command, command.Command)
+		assert.Equal(t, fakeConn.command.User, command.User)
+		assert.Equal(t, fakeConn.command.Env, command.Env)
+	})
+	t.Run("get variables for task", func(t *testing.T) {
+		assert.Equal(t, context.Get("variable"), "value")
+	})
+}

--- a/schema/fakes_test.go
+++ b/schema/fakes_test.go
@@ -1,0 +1,32 @@
+package schema
+
+import "github.com/pythonandchips/azad/conn"
+
+type FakeConn struct {
+	response conn.Response
+	command  conn.Command
+}
+
+func (fakeConn *FakeConn) ConnectTo(string) error {
+	return nil
+}
+
+func (fakeConn *FakeConn) Run(command conn.Command) (conn.Response, error) {
+	fakeConn.command = command
+	return fakeConn.response, nil
+}
+
+func (fakeConn *FakeConn) Close() {}
+
+type FakeResponse struct {
+	stdout string
+	stderr string
+}
+
+func (fakeResponse FakeResponse) Stdout() string {
+	return fakeResponse.stdout
+}
+
+func (fakeResponse FakeResponse) Stderr() string {
+	return fakeResponse.stderr
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,7 +1,5 @@
 package schema
 
-import "github.com/pythonandchips/azad/conn"
-
 // Schema schema
 type Schema struct {
 	Tasks  []Task
@@ -12,7 +10,7 @@ type Schema struct {
 type Task struct {
 	Name   string
 	Fields []Field
-	Run    func(map[string]string, conn.Conn) error
+	Run    func(Context) error
 }
 
 // Field field
@@ -22,6 +20,14 @@ type Field struct {
 	Required bool
 }
 
-func BuildSchema() Schema {
-	return Schema{}
+// Command represents a command to be ran on a remote host
+type Command struct {
+	// Interpreter used to run command e.g. sh, bash, ruby
+	Interpreter string
+	// Command lines used to make up a command to be ran
+	Command []string
+	// Additional environment variable to be used in the command
+	Env map[string]string
+	// User to run the command with e.g. root, admin
+	User string
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,12 +1,1 @@
 package schema
-
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
-
-func TestBuildField(t *testing.T) {
-	schema := BuildSchema()
-	assert.Equal(t, schema, Schema{})
-}


### PR DESCRIPTION
Introduce a context object to contain all information requried for a task to be completed.

This adds an abstraction around connections to the server to all for internal changes of azad while keeping the interface for plugins consistant.
