### PR TITLE
Add ssh key option and pass to connection

### DIFF
--- a/azad/config.go
+++ b/azad/config.go
@@ -1,3 +1,19 @@
 package azad
 
-type Config struct{}
+import "github.com/pythonandchips/azad/conn"
+
+// Config for azad
+type Config struct {
+	KeyFilePath string
+}
+
+// SSHConfig extract config from main configuration
+func (config Config) SSHConfig() conn.Config {
+	keyFilePath := config.KeyFilePath
+	if keyFilePath == "" {
+		keyFilePath = conn.DefaultSSHKeyPath()
+	}
+	return conn.Config{
+		KeyFilePath: keyFilePath,
+	}
+}

--- a/azad/config_test.go
+++ b/azad/config_test.go
@@ -1,0 +1,26 @@
+package azad
+
+import (
+	"testing"
+
+	"github.com/pythonandchips/azad/conn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigSSHConfig(t *testing.T) {
+	t.Run("returns the ssh config", func(t *testing.T) {
+		config := Config{
+			KeyFilePath: "keyFilePath",
+		}
+		connConfig := config.SSHConfig()
+
+		assert.Equal(t, connConfig.KeyFilePath, config.KeyFilePath)
+	})
+
+	t.Run("default path if ssh key not set", func(t *testing.T) {
+		config := Config{}
+		connConfig := config.SSHConfig()
+
+		assert.Equal(t, connConfig.KeyFilePath, conn.DefaultSSHKeyPath())
+	})
+}

--- a/cli/action_handler.go
+++ b/cli/action_handler.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/urfave/cli"
+
+func actionHander(f func(context) error) func(*cli.Context) error {
+	return func(c *cli.Context) error {
+		return f(cliContext{c})
+	}
+}

--- a/cli/context.go
+++ b/cli/context.go
@@ -1,0 +1,30 @@
+package main
+
+import "github.com/urfave/cli"
+
+type context interface {
+	Bool(string) bool
+	Args() cli.Args
+	NArg() int
+	String(string) string
+}
+
+type cliContext struct {
+	context *cli.Context
+}
+
+func (context cliContext) Bool(key string) bool {
+	return context.context.Bool(key)
+}
+
+func (context cliContext) Args() cli.Args {
+	return context.context.Args()
+}
+
+func (context cliContext) NArg() int {
+	return context.context.NArg()
+}
+
+func (context cliContext) String(key string) string {
+	return context.String(key)
+}

--- a/cli/fakes_test.go
+++ b/cli/fakes_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "github.com/urfave/cli"
+
+type FakeContext struct {
+	bools   map[string]bool
+	strings map[string]string
+	args    []string
+}
+
+func (fakeContext FakeContext) Bool(key string) bool {
+	return fakeContext.bools[key]
+}
+
+func (fakeContext FakeContext) Args() cli.Args {
+	return fakeContext.args
+}
+
+func (fakeContext FakeContext) NArg() int {
+	return len(fakeContext.args)
+}
+
+func (fakeContext FakeContext) String(key string) string {
+	return fakeContext.strings[key]
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -4,11 +4,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/pythonandchips/azad/azad"
 	"github.com/pythonandchips/azad/conn"
 	"github.com/pythonandchips/azad/logger"
 	"github.com/pythonandchips/azad/plugins"
-	"github.com/pythonandchips/azad/runner"
 	"github.com/urfave/cli"
 )
 
@@ -16,16 +14,20 @@ func main() {
 	plugins.Configure()
 	logger.Initialize()
 
-	app := cli.NewApp()
-	app.Name = "Azad: Server Configuration Management"
-	app.Flags = flags()
-	app.Action = runPlaybook
-
+	app := app()
 	err := app.Run(os.Args)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func app() *cli.App {
+	app := cli.NewApp()
+	app.Name = "Azad: Server Configuration Management"
+	app.Flags = flags()
+	app.Action = actionHander(runPlaybook)
+	return app
 }
 
 func flags() []cli.Flag {
@@ -35,23 +37,14 @@ func flags() []cli.Flag {
 			Value: "root",
 			Usage: "user for ssh connection",
 		},
+		cli.StringFlag{
+			Name:  "key, k",
+			Value: conn.DefaultSSHKeyPath(),
+			Usage: "ssh key used to connect to server",
+		},
 		cli.BoolFlag{
 			Name:  "simulate, s",
 			Usage: "Simulate run and output script to stdout, used for development",
 		},
 	}
-}
-
-func runPlaybook(c *cli.Context) error {
-	if c.Bool("simulate") {
-		logger.Info("Simulating run, no change will be made to server")
-		conn.Simulate()
-	}
-	playbookFilePath := "./playbook.az"
-	if c.NArg() > 0 {
-		playbookFilePath = c.Args().Get(0)
-	}
-	logger.Info("Applying %s", playbookFilePath)
-	runner.RunPlaybook(playbookFilePath, azad.Config{})
-	return nil
 }

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/cli/run_playbook.go
+++ b/cli/run_playbook.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/pythonandchips/azad/azad"
+	"github.com/pythonandchips/azad/conn"
+	"github.com/pythonandchips/azad/logger"
+	"github.com/pythonandchips/azad/runner"
+)
+
+func runPlaybook(c context) error {
+	if c.Bool("simulate") {
+		logger.Info("Simulating run, no change will be made to server")
+		conn.Simulate()
+	}
+	playbookFilePath := "./playbook.az"
+	if c.NArg() > 0 {
+		playbookFilePath = c.Args().Get(0)
+	}
+	logger.Info("Applying %s", playbookFilePath)
+	runner.RunPlaybook(playbookFilePath, azad.Config{
+		KeyFilePath: c.String("key"),
+	})
+	return nil
+}

--- a/cli/run_playbook_test.go
+++ b/cli/run_playbook_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pythonandchips/azad/azad"
+	"github.com/pythonandchips/azad/conn"
+	"github.com/pythonandchips/azad/logger"
+	"github.com/pythonandchips/azad/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunPlaybook(t *testing.T) {
+	logger.StubLogger()
+	var specifiedPlaybookFilePath string
+	var specifiedConfig azad.Config
+	simulation := false
+	runner.RunPlaybook = func(playbookFilePath string, config azad.Config) {
+		specifiedPlaybookFilePath = playbookFilePath
+		specifiedConfig = config
+	}
+	conn.Simulate = func() {
+		simulation = true
+	}
+	t.Run("passes the correct playbook path to the runner", func(t *testing.T) {
+		fakeContext := FakeContext{
+			args: []string{"test_playbook.az"},
+			strings: map[string]string{
+				"key": "path_to_key",
+			},
+		}
+		runPlaybook(fakeContext)
+		assert.Equal(t, specifiedPlaybookFilePath, "test_playbook.az")
+		assert.Equal(t, specifiedConfig.KeyFilePath, "path_to_key")
+		assert.False(t, simulation)
+	})
+	t.Run("uses the default playbook if one is not specified", func(t *testing.T) {
+		fakeContext := FakeContext{
+			args: []string{},
+			strings: map[string]string{
+				"key": "path_to_key",
+			},
+		}
+		runPlaybook(fakeContext)
+		assert.Equal(t, specifiedPlaybookFilePath, "./playbook.az")
+	})
+	t.Run("set conn to simulate when simulate switch set", func(t *testing.T) {
+		fakeContext := FakeContext{
+			args: []string{},
+			bools: map[string]bool{
+				"simulate": true,
+			},
+		}
+		runPlaybook(fakeContext)
+		assert.True(t, simulation)
+	})
+}

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -1,6 +1,11 @@
 package conn
 
-import "bytes"
+import (
+	"bytes"
+	"path/filepath"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
 
 type Conn interface {
 	ConnectTo(string) error
@@ -10,15 +15,27 @@ type Conn interface {
 
 var NewConn = newConn
 
-func newConn() Conn {
-	return &SSHConn{}
+func newConn(config Config) Conn {
+	return &SSHConn{
+		config: config,
+	}
 }
 
-func newFakeConn() Conn {
+func newFakeConn(config Config) Conn {
 	return &LoggerSSHConn{}
 }
 
-func Simulate() {
+// DefaultSSHKeyPath returns default path for ssh key
+//
+// $HOME/.ssh/id_rsa
+func DefaultSSHKeyPath() string {
+	home, _ := homedir.Dir()
+	return filepath.Join(home, ".ssh", "id_rsa")
+}
+
+// Simulate switch connection to output to
+// stdout instead of run on server
+var Simulate = func() {
 	NewConn = newFakeConn
 }
 

--- a/conn/conn_test.go
+++ b/conn/conn_test.go
@@ -1,0 +1,14 @@
+package conn
+
+import (
+	"testing"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultSSHKeyPath(t *testing.T) {
+	defaultSSHKeyPath := DefaultSSHKeyPath()
+	home, _ := homedir.Dir()
+	assert.Equal(t, defaultSSHKeyPath, home+"/.ssh/id_rsa")
+}

--- a/conn/ssh_conn.go
+++ b/conn/ssh_conn.go
@@ -4,25 +4,28 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"time"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pythonandchips/azad/logger"
 	"golang.org/x/crypto/ssh"
 )
 
+// Config for connection
+type Config struct {
+	KeyFilePath string
+}
+
 func (sshConn *SSHConn) ConnectTo(ip string) error {
-	home, _ := homedir.Dir()
-	keyPath := filepath.Join(home, ".ssh", "id_rsa")
-	key, err := ioutil.ReadFile(keyPath)
+	key, err := ioutil.ReadFile(sshConn.config.KeyFilePath)
 	if err != nil {
-		return fmt.Errorf("Unable to read private key %s", keyPath)
+		return fmt.Errorf("Unable to read private key %s", sshConn.config.KeyFilePath)
 	}
+	logger.Info("Using key %s", sshConn.config.KeyFilePath)
 
 	// Create the Signer for this private key.
 	signer, err := ssh.ParsePrivateKey(key)
 	if err != nil {
-		return fmt.Errorf("Unable to parse private key: %v\n", err)
+		return fmt.Errorf("unable to parse private key: %v", err)
 	}
 
 	config := &ssh.ClientConfig{
@@ -93,4 +96,5 @@ func (sshConn *SSHConn) Close() {
 // SSHConn manage connections
 type SSHConn struct {
 	client sshClient
+	config Config
 }

--- a/conn/wrappers.go
+++ b/conn/wrappers.go
@@ -28,5 +28,5 @@ func (sshSessionWrapper sshSessionWrapper) setStderr(stderr *bytes.Buffer) {
 }
 
 func (sshSessionWrapper sshSessionWrapper) Run(command string) error {
-	return sshSessionWrapper.Run(command)
+	return sshSessionWrapper.Session.Run(command)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -12,6 +13,15 @@ var debug *log.Logger
 var warn *log.Logger
 var err *log.Logger
 
+// StubLogger sends all logs to /dev/null
+func StubLogger() {
+	info = log.New(ioutil.Discard, "", 0)
+	debug = log.New(ioutil.Discard, "", 0)
+	warn = log.New(ioutil.Discard, "", 0)
+	err = log.New(ioutil.Discard, "", 0)
+}
+
+// Initialize loggers for each level
 func Initialize() {
 	info = log.New(os.Stdout, color.BlueString("[INFO] "), 0)
 	debug = log.New(os.Stdout, color.GreenString("[DEBUG] "), 0)
@@ -19,18 +29,22 @@ func Initialize() {
 	err = log.New(os.Stderr, color.RedString("[ERROR] "), 0)
 }
 
+// Info log to info level
 func Info(line string, params ...interface{}) {
 	info.Printf(line+"\n", params...)
 }
 
+// Debug log to debug level
 func Debug(line string, params ...interface{}) {
 	debug.Printf(line+"\n", params...)
 }
 
+// Warn log to warn level
 func Warn(line string, params ...interface{}) {
 	warn.Printf(line+"\n", params...)
 }
 
+// Error log to error level
 func Error(line string, params ...interface{}) {
 	err.Printf(line+"\n", params...)
 }

--- a/runner/run_playbook.go
+++ b/runner/run_playbook.go
@@ -24,8 +24,11 @@ type runner struct {
 	Variables map[string]string
 }
 
+var config azad.Config
+
 // RunPlaybook run the playbook
-func RunPlaybook(playbookFilePath string, config azad.Config) {
+var RunPlaybook = func(playbookFilePath string, globalConfig azad.Config) {
+	config = globalConfig
 	env := map[string]string{}
 	playbook, err := parser.PlaybookFromFile(playbookFilePath, env)
 	if err != nil {
@@ -60,7 +63,7 @@ func createRunners(addresses []string) (runners, error) {
 	runners := runners{}
 	errors := &multierror.Error{}
 	for _, address := range addresses {
-		connection := conn.NewConn()
+		connection := conn.NewConn(config.SSHConfig())
 		err := connection.ConnectTo(address)
 		if err != nil {
 			errors = multierror.Append(errors, err)


### PR DESCRIPTION
Allow user to specify an ssh key used to connect to the server e.g. `azad -k ~/.ssh/other_key`

Additonally introduces wrapper around urfave/cli Context to allow for testing around cli actions

resolves #3 