### PR TITLE
Organise roles in own directories

### DIFF
--- a/azad/playbook.go
+++ b/azad/playbook.go
@@ -57,3 +57,13 @@ func (playbook Playbook) FindRole(roleName string) (Role, error) {
 	}
 	return Role{}, fmt.Errorf("Role %s not found", roleName)
 }
+
+// ContainsRole test if playbook contains a role by name
+func (playbook Playbook) ContainsRole(roleName string) bool {
+	for _, role := range playbook.Roles {
+		if role.Name == roleName {
+			return true
+		}
+	}
+	return false
+}

--- a/parser/fixtures/roles_per_folder/basic.az
+++ b/parser/fixtures/roles_per_folder/basic.az
@@ -1,0 +1,12 @@
+server "tag_kibana_server" {
+  addresses = [
+    "10.0.0.1"
+  ]
+}
+
+host "tag_kibana_server" {
+  roles = [
+    "ruby"
+  ]
+}
+

--- a/parser/fixtures/roles_per_folder/roles/ruby/ruby.az
+++ b/parser/fixtures/roles_per_folder/roles/ruby/ruby.az
@@ -1,0 +1,7 @@
+task "apt-get.update" "update apt get" {
+  user = "root"
+}
+
+task "apt-get" "install ruby" {
+  pgk = "libv8"
+}

--- a/parser/fixtures/roles_per_folder/roles/security/firewall/firewall.az
+++ b/parser/fixtures/roles_per_folder/roles/security/firewall/firewall.az
@@ -1,0 +1,3 @@
+task "bash" "add-port" {
+  command = "iptables.restore"
+}

--- a/parser/fixtures/roles_per_folder/roles/security/patches/patches.az
+++ b/parser/fixtures/roles_per_folder/roles/security/patches/patches.az
@@ -1,0 +1,3 @@
+task "bash" "install patch" {
+  command = "apt-get install patch"
+}

--- a/parser/load_config.go
+++ b/parser/load_config.go
@@ -1,36 +1,144 @@
 package parser
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/hcl2/gohcl"
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 )
 
-func loadConfigFile(fileName string) (playbookDescription, error) {
-	data, err := ioutil.ReadFile(fileName)
+func loadConfigFile(filename string) (playbookDescription, error) {
+	playbookDescription, err := parsePlaybookConfig(filename)
 	if err != nil {
-		return playbookDescription{}, err
+		return playbookDescription, err
 	}
-	return parseConfig(data)
+	roleDescriptions, err := parseRoles(filename)
+	if err != nil {
+		return playbookDescription, err
+	}
+	playbookDescription.Roles = append(playbookDescription.Roles, roleDescriptions...)
+	return playbookDescription, err
 }
 
-func parseConfig(playbookConfig []byte) (playbookDescription, error) {
+func parsePlaybookConfig(filename string) (playbookDescription, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return playbookDescription{}, nil
+	}
 	playbook := playbookDescription{}
-	file, err := hclsyntax.ParseConfig(
-		playbookConfig,
+	file, parseErr := hclsyntax.ParseConfig(
+		data,
 		"config",
 		hcl.Pos{Line: 1, Column: 1},
 	)
 
-	if err.HasErrors() {
+	if parseErr.HasErrors() {
 		return playbook, err
 	}
 
-	if err = gohcl.DecodeBody(file.Body, nil, &playbook); err.HasErrors() {
-		return playbook, err
+	if parseErr = gohcl.DecodeBody(file.Body, nil, &playbook); parseErr.HasErrors() {
+		return playbook, parseErr
 	}
 
 	return playbook, nil
+}
+
+func parseRoles(filename string) (roleDescriptions, error) {
+	dirPath := filepath.Dir(filename)
+	rolesFolderPath := filepath.Join(dirPath, "roles")
+	roleDescriptions := roleDescriptions{}
+
+	err := filepath.Walk(rolesFolderPath, func(path string, info os.FileInfo, err error) error {
+		if path == rolesFolderPath {
+			return nil
+		}
+		roleDescriptions, err = handleFilePath(roleDescriptions, rolesFolderPath, path, info)
+		return err
+	})
+
+	return roleDescriptions, err
+}
+
+func handleFilePath(
+	roleDescriptions roleDescriptions,
+	rolesFolderPath, path string,
+	info os.FileInfo,
+) (roleDescriptions, error) {
+	// Ignore roles folder, all roles must be contained in a folder
+	if info.IsDir() {
+		roleDescription, err := createRoleDescriptionFromFolder(rolesFolderPath, path)
+		if err != nil {
+			return roleDescriptions, nil
+		}
+		roleDescriptions = append(roleDescriptions, roleDescription)
+		return roleDescriptions, nil
+	}
+	// only parse file with .az extension
+	if filepath.Ext(path) != ".az" {
+		return roleDescriptions, nil
+	}
+	err := createRoleFromConfig(path, rolesFolderPath, roleDescriptions)
+	return roleDescriptions, err
+}
+
+func createRoleFromConfig(
+	path, rolesFolderPath string,
+	roleDescriptions roleDescriptions,
+) error {
+	dirPath := filepath.Dir(path)
+	roleName, err := filepath.Rel(rolesFolderPath, dirPath)
+	if err != nil {
+		return err
+	}
+	role, err := roleDescriptions.RoleFor(roleName)
+	if err != nil {
+		return err
+	}
+	err = parseRoleConfig(path, &role)
+	if err != nil {
+		return fmt.Errorf("Failed to parse role %s: %s", roleName, err)
+	}
+	roleDescriptions.ReplaceWith(role)
+	return nil
+}
+
+func parseRoleConfig(path string, role *roleDescription) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	file, parseErr := hclsyntax.ParseConfig(
+		data,
+		"config",
+		hcl.Pos{Line: 1, Column: 1},
+	)
+
+	if parseErr.HasErrors() {
+		return parseErr
+	}
+	if parseErr = gohcl.DecodeBody(file.Body, nil, role); parseErr.HasErrors() {
+		return parseErr
+	}
+	return nil
+}
+
+func createRoleDescriptionFromFolder(rolesFolderPath, path string) (roleDescription, error) {
+	globPath := filepath.Join(path, "*.az")
+	azadFiles, _ := filepath.Glob(globPath)
+	// Ignore folders that do not contain any azad file
+	if len(azadFiles) == 0 {
+		return roleDescription{}, fmt.Errorf("No azad files found")
+	}
+	roleName, err := filepath.Rel(rolesFolderPath, path)
+	if err != nil {
+		return roleDescription{}, fmt.Errorf("Unable to find relative path")
+	}
+	roleDescription := roleDescription{
+		Name: roleName,
+	}
+	return roleDescription, nil
 }

--- a/parser/parse_roles_per_folder_test.go
+++ b/parser/parse_roles_per_folder_test.go
@@ -1,0 +1,69 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRolesPerFolder(t *testing.T) {
+	wd, _ := os.Getwd()
+	filePath := filepath.Join(wd, "fixtures", "roles_per_folder", "basic.az")
+	env := map[string]string{}
+
+	playbook, err := PlaybookFromFile(filePath, env)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	t.Run("returns the server with addresses", func(t *testing.T) {
+		servers := playbook.Servers
+		if len(servers) != 1 {
+			t.Fatalf("Expected %d servers but got %d", 1, len(servers))
+		}
+
+		server := servers[0]
+		assert.Equal(t, server.Group, "tag_kibana_server")
+		if len(server.Addresses) != 1 {
+			t.Fatalf("Expected server with %d addresses but had %d", 1, len(server.Addresses))
+		}
+
+		address := server.Addresses[0]
+		assert.Equal(t, address, "10.0.0.1")
+	})
+
+	t.Run("returns the host configuration", func(t *testing.T) {
+		hosts := playbook.Hosts
+		if len(hosts) != 1 {
+			t.Fatalf("Expected %d hosts but got %d", 1, len(hosts))
+		}
+
+		host := hosts[0]
+		assert.Equal(t, host.ServerGroup, "tag_kibana_server")
+		if len(host.Roles) != 1 {
+			t.Fatalf("Expected host with %d roles but got %d", 1, len(host.Roles))
+		}
+		assert.Equal(t, host.Roles, []string{"ruby"})
+	})
+
+	t.Run("returns the roles configuration", func(t *testing.T) {
+		roles := playbook.Roles
+		if len(roles) != 3 {
+			t.Fatalf("Expected %d roles but got %d", 3, len(roles))
+		}
+		assert.True(t, playbook.ContainsRole("ruby"), "Expected playbook to contain ruby role")
+		assert.True(t, playbook.ContainsRole("security/firewall"), "expected playbook to contain security/firewall role")
+		assert.True(t, playbook.ContainsRole("security/patches"), "expected playbook to contain security/patches role")
+
+		t.Run("parses tasks for role", func(t *testing.T) {
+			rubyRole, _ := playbook.FindRole("ruby")
+
+			if len(rubyRole.Tasks) != 2 {
+				t.Fatalf("Expected %d tasks but got %d", 2, len(rubyRole.Tasks))
+			}
+		})
+	})
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,14 +1,10 @@
 package parser
 
 import (
-	"errors"
-
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/pythonandchips/azad/azad"
 	"github.com/zclconf/go-cty/cty"
 )
-
-var errNoEnv = errors.New("No environment variables")
 
 // PlaybookFromFile return a playbook
 func PlaybookFromFile(path string, env map[string]string) (azad.Playbook, error) {
@@ -23,7 +19,11 @@ func PlaybookFromFile(path string, env map[string]string) (azad.Playbook, error)
 		return azad.Playbook{}, err
 	}
 	variables, err := unpackVariables(playbookDescription.Variables)
-	evalContext.Variables["var"] = cty.MapVal(variables)
+	if len(variables) == 0 {
+		evalContext.Variables["var"] = cty.MapValEmpty(cty.String)
+	} else {
+		evalContext.Variables["var"] = cty.MapVal(variables)
+	}
 	servers, err := unpackServer(playbookDescription.Servers)
 	if err != nil {
 		return azad.Playbook{}, err
@@ -43,7 +43,7 @@ func envToVariables(env map[string]string) (cty.Value, error) {
 		variables[key] = cty.StringVal(val)
 	}
 	if len(variables) == 0 {
-		return cty.StringVal(""), errNoEnv
+		return cty.MapValEmpty(cty.String), nil
 	}
 	return cty.MapVal(variables), nil
 }

--- a/parser/playbook_description.go
+++ b/parser/playbook_description.go
@@ -1,6 +1,10 @@
 package parser
 
-import "github.com/hashicorp/hcl2/hcl"
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl2/hcl"
+)
 
 type playbookDescription struct {
 	Servers   []serverDescription   `hcl:"server,block"`
@@ -19,6 +23,25 @@ type serverDescription struct {
 type variableDescription struct {
 	Name    string `hcl:",label"`
 	Default string `hcl:"default"`
+}
+
+type roleDescriptions []roleDescription
+
+func (roleDescriptions roleDescriptions) RoleFor(name string) (roleDescription, error) {
+	for _, roleDescription := range roleDescriptions {
+		if roleDescription.Name == name {
+			return roleDescription, nil
+		}
+	}
+	return roleDescription{}, fmt.Errorf("role with name %s not found", name)
+}
+
+func (roleDescriptions roleDescriptions) ReplaceWith(role roleDescription) {
+	for i, roleDescription := range roleDescriptions {
+		if roleDescription.Name == role.Name {
+			roleDescriptions[i] = role
+		}
+	}
 }
 
 // Role list of task to be applied to host


### PR DESCRIPTION
Roles can be specified in the roles directory.

Any directory that contains at least one `.az` file will be converted to
a role. The Role name is taken from the path relative to the roles
directory. Eg. A role defined in `./roles/security/firewall` translates
to role `security/firewall`

Resolves #10