### PR TITLE
Allow roles to have dependents roles

### DIFF
--- a/azad/role.go
+++ b/azad/role.go
@@ -1,7 +1,23 @@
 package azad
 
+import "fmt"
+
+// Roles collection of role's
+type Roles []Role
+
+// FindRole find role in collection
+func (roles Roles) FindRole(roleName string) (Role, error) {
+	for _, role := range roles {
+		if role.Name == roleName {
+			return role, nil
+		}
+	}
+	return Role{}, fmt.Errorf("Role %s not found", roleName)
+}
+
 // Role list of task to be applied to host
 type Role struct {
-	Name  string
-	Tasks Tasks
+	Name       string
+	Dependents []string
+	Tasks      Tasks
 }

--- a/parser/fixtures/basic.az
+++ b/parser/fixtures/basic.az
@@ -22,4 +22,6 @@ role "elasticsearch" {
   task "bash" "restart-nginx" {
     command = "echo \"ran via azad\" >> ${ var.output_file }"
   }
+
+  dependents = ["java"]
 }

--- a/parser/parse_basic_playbook_test.go
+++ b/parser/parse_basic_playbook_test.go
@@ -59,6 +59,7 @@ func TestPlaybookFromFileBasic(t *testing.T) {
 		}
 		role := playbook.Roles[0]
 		assert.Equal(t, role.Name, "elasticsearch")
+		assert.Equal(t, role.Dependents, []string{"java"})
 
 		t.Run("parses the tasks for the role", func(t *testing.T) {
 			tasks := role.Tasks

--- a/parser/playbook_description.go
+++ b/parser/playbook_description.go
@@ -52,9 +52,10 @@ func (roleDescriptions roleDescriptions) ReplaceWith(role roleDescription) {
 
 // Role list of task to be applied to host
 type roleDescription struct {
-	Name   string            `hcl:",label"`
-	Tasks  []taskDescription `hcl:"task,block"`
-	Config hcl.Body          `hcl:",remain"`
+	Name       string            `hcl:",label"`
+	Dependents []string          `hcl:"dependents,optional"`
+	Tasks      []taskDescription `hcl:"task,block"`
+	Config     hcl.Body          `hcl:",remain"`
 }
 
 // Task run command via ssh

--- a/parser/unpack_roles.go
+++ b/parser/unpack_roles.go
@@ -8,7 +8,10 @@ import (
 func unpackRoles(rolesDescriptions []roleDescription, evalContext *hcl.EvalContext) ([]azad.Role, error) {
 	roles := []azad.Role{}
 	for _, roleDescription := range rolesDescriptions {
-		role := azad.Role{Name: roleDescription.Name}
+		role := azad.Role{
+			Name:       roleDescription.Name,
+			Dependents: roleDescription.Dependents,
+		}
 		tasks, _ := unpackTasks(roleDescription.Tasks, evalContext)
 		role.Tasks = tasks
 		roles = append(roles, role)


### PR DESCRIPTION
Dependents roles can be defined in a playbook using the dependents
attribute e.g.

```
role "elastic_search" {
  ...
  dependents = ["install_java"]
}
```

This will treverse the list of dependents and create a list of tasks to
run.

Roles will be duplicated if they are used in multiple roles.

The run will fail if there is a dependency loop and stop the run
immediately

Resolves #15 