### PR TITLE
Allow tasks to be marked as conditional

### DIFF
--- a/azad/task.go
+++ b/azad/task.go
@@ -36,6 +36,7 @@ type Task struct {
 	Type       string
 	Name       string
 	Attributes map[string]*hcl.Attribute
+	Condition  *hcl.Attribute
 }
 
 // PluginName name of plugin

--- a/parser/fixtures/basic.az
+++ b/parser/fixtures/basic.az
@@ -25,6 +25,7 @@ role "elasticsearch" {
 
   task "bash" "restart-nginx" {
     command = "echo \"does ruby exist ${ ruby-exists.exists }\" >> ${ var.output_file }"
+    condition = "${not(ruby-exists.exists)}"
   }
 
   dependents = ["java"]

--- a/parser/parse_basic_playbook_test.go
+++ b/parser/parse_basic_playbook_test.go
@@ -72,6 +72,10 @@ func TestPlaybookFromFileBasic(t *testing.T) {
 			assert.Equal(t, task.Name, "ruby-exists")
 
 			assert.Equal(t, task.Attributes["path"].Name, "path")
+			t.Run("parse task with a conditional", func(t *testing.T) {
+				conditionalTask := role.Tasks[1]
+				assert.NotNil(t, conditionalTask.Condition)
+			})
 		})
 	})
 }

--- a/parser/role_description.go
+++ b/parser/role_description.go
@@ -51,7 +51,6 @@ type roleDescription struct {
 	Name       string   `hcl:",label"`
 	Dependents []string `hcl:"dependents,optional"`
 	Config     hcl.Body `hcl:",remain"`
-	// Tasks      []taskDescription `hcl:"task,block"`
 }
 
 // Task run command via ssh

--- a/parser/unpack_roles.go
+++ b/parser/unpack_roles.go
@@ -88,6 +88,10 @@ func unpackTask(body *hcl.Block, evalContext *hcl.EvalContext) (azad.Task, error
 	attributes := map[string]*hcl.Attribute{}
 	attributesList, _ := body.Body.JustAttributes()
 	for _, attr := range attributesList {
+		if attr.Name == "condition" {
+			task.Condition = attr
+			continue
+		}
 		attributes[attr.Name] = attr
 	}
 	task.Attributes = attributes

--- a/runner/run_task.go
+++ b/runner/run_task.go
@@ -5,21 +5,30 @@ import (
 	"github.com/pythonandchips/azad/azad"
 	"github.com/pythonandchips/azad/logger"
 	"github.com/pythonandchips/azad/plugin"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
 )
 
 func runTask(task azad.Task, taskSchema plugin.Task, runner *runner) error {
 	logger.Info("Applying %s:%s on %s", task.Type, task.Name, runner.Address)
-	vars := map[string]string{}
-	for _, field := range taskSchema.Fields {
-		evalContext := &hcl.EvalContext{
-			Variables: runner.toContext(),
-		}
-		attr := task.Attributes[field.Name]
-		value, err := attr.Expr.Value(evalContext)
+	evalContext := &hcl.EvalContext{
+		Variables: runner.toContext(),
+		Functions: stdFunctions(),
+	}
+	if task.Condition != nil {
+		result, err := task.Condition.Expr.Value(evalContext)
 		if err != nil {
+			logger.Error("Error evaluating conditional %s:%s on %s: %s", task.Type, task.Name, runner.Address, err)
 			return err
 		}
-		vars[field.Name] = value.AsString()
+		if result.True() {
+			logger.Info("Skipping %s:%s on %s, condition failed", task.Type, task.Name, runner.Address)
+			return nil
+		}
+	}
+	vars, err := varsForTask(taskSchema.Fields, task, evalContext)
+	if err != nil {
+		return err
 	}
 	context := plugin.NewContext(vars, runner.Conn)
 	results, err := taskSchema.Run(context)
@@ -31,4 +40,50 @@ func runTask(task azad.Task, taskSchema plugin.Task, runner *runner) error {
 	runner.setResult(task.Name, results)
 	logger.Info("Success %s:%s on %s", task.Type, task.Name, runner.Address)
 	return nil
+}
+
+func varsForTask(fields []plugin.Field, task azad.Task, evalContext *hcl.EvalContext) (map[string]string, error) {
+	vars := map[string]string{}
+	for _, field := range fields {
+		attr := task.Attributes[field.Name]
+		value, err := attr.Expr.Value(evalContext)
+		if err != nil {
+			return vars, err
+		}
+		vars[field.Name] = value.AsString()
+	}
+	return vars, nil
+}
+
+func stdFunctions() map[string]function.Function {
+	return map[string]function.Function{
+		"not": function.New(&function.Spec{
+			Params: []function.Parameter{
+				{
+					Name:             "val",
+					Type:             cty.String,
+					AllowDynamicType: true,
+				},
+			},
+			Type: function.StaticReturnType(cty.Bool),
+			Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+				val := args[0] != cty.StringVal("true")
+				return cty.BoolVal(val), nil
+			},
+		}),
+		"is": function.New(&function.Spec{
+			Params: []function.Parameter{
+				{
+					Name:             "val",
+					Type:             cty.String,
+					AllowDynamicType: true,
+				},
+			},
+			Type: function.StaticReturnType(cty.Bool),
+			Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+				val := args[0] == cty.StringVal("true")
+				return cty.BoolVal(val), nil
+			},
+		}),
+	}
 }


### PR DESCRIPTION
This is a first pass at conditionals for tasks. Conditionals can be
defined by applying the `condition` attribute to tasks.

They are currently limited to evaluating a `true` or `false` string value
returned by a task or set in a variable. They must be wrapped in a `not`
or `is` function within the expression.

For example

```
task "dpkg.package-details" "ruby-package" {
  package = "ruby"
}

task "apt-get" "install-ruby" {
  package = "ruby"
  condition = "${not(ruby-package.installed)}"
}
```

Resolves #22 