### PR TITLE
Scope variables

### DIFF
--- a/azad/host.go
+++ b/azad/host.go
@@ -1,7 +1,10 @@
 package azad
 
+import "github.com/zclconf/go-cty/cty"
+
 // Host name and roles of server
 type Host struct {
 	ServerGroup string
-	Roles       []string
+	Roles       []Role
+	Variables   map[string]cty.Value
 }

--- a/azad/playbook.go
+++ b/azad/playbook.go
@@ -2,9 +2,9 @@ package azad
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pythonandchips/azad/helpers/stringslice"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Playbook describes servers and there roles
@@ -12,7 +12,7 @@ type Playbook struct {
 	Inventories []Inventory
 	Servers     []Server
 	Hosts       []Host
-	Roles       Roles
+	Variables   map[string]cty.Value
 }
 
 // LookupServer lookup server
@@ -46,9 +46,11 @@ func (playbook *Playbook) AddAddressToServerByGroup(group, address string) {
 // ListTasks list tasks
 func (playbook Playbook) ListTasks() Tasks {
 	tasks := Tasks{}
-	for _, role := range playbook.Roles {
-		for _, task := range role.Tasks {
-			tasks = append(tasks, task)
+	for _, host := range playbook.Hosts {
+		for _, role := range host.Roles {
+			for _, task := range role.Tasks {
+				tasks = append(tasks, task)
+			}
 		}
 	}
 	return tasks
@@ -57,48 +59,4 @@ func (playbook Playbook) ListTasks() Tasks {
 // RequiredTasks list tasks required for playbook
 func (playbook Playbook) RequiredTasks() Tasks {
 	return playbook.ListTasks().UniqueTypes()
-}
-
-// TasksForRoles tasks for role
-func (playbook Playbook) TasksForRoles(roleNames []string) (Tasks, error) {
-	return playbook.tasksForRolesWithDependentCheck(roleNames, []string{})
-}
-
-func (playbook Playbook) tasksForRolesWithDependentCheck(roleNames []string, pastRuns []string) (Tasks, error) {
-	tasks := Tasks{}
-	for _, roleName := range roleNames {
-		if stringslice.Exists(roleName, pastRuns) {
-			pastRuns = append(pastRuns, roleName)
-			path := strings.Join(pastRuns, " > ")
-			return tasks, fmt.Errorf("dependent Loop detected %s", path)
-		}
-		pastRuns = append(pastRuns, roleName)
-		role, err := playbook.FindRole(roleName)
-		if err != nil {
-			return tasks, err
-		}
-		dependentTasks, err := playbook.tasksForRolesWithDependentCheck(role.Dependents, pastRuns)
-		if err != nil {
-			return tasks, err
-		}
-		tasks = append(tasks, dependentTasks...)
-		tasks = append(tasks, role.Tasks...)
-		pastRuns = pastRuns[:len(pastRuns)-1]
-	}
-	return tasks, nil
-}
-
-// FindRole find role
-func (playbook Playbook) FindRole(roleName string) (Role, error) {
-	return playbook.Roles.FindRole(roleName)
-}
-
-// ContainsRole test if playbook contains a role by name
-func (playbook Playbook) ContainsRole(roleName string) bool {
-	for _, role := range playbook.Roles {
-		if role.Name == roleName {
-			return true
-		}
-	}
-	return false
 }

--- a/azad/playbook_test.go
+++ b/azad/playbook_test.go
@@ -8,15 +8,19 @@ import (
 
 func TestPlaybookListRequirements(t *testing.T) {
 	playbook := Playbook{
-		Roles: []Role{
+		Hosts: []Host{
 			{
-				Name: "elastic_search",
-				Tasks: []Task{
-					{Type: "bash", Name: "list files"},
-					{Type: "debian.apt-get", Name: "list files"},
-					{Type: "credstash.lookup", Name: "list files"},
-					{Type: "debian.apt-get", Name: "list files"},
-					{Type: "debian.chmod", Name: "list files"},
+				Roles: []Role{
+					{
+						Name: "elastic_search",
+						Tasks: []Task{
+							{Type: "bash", Name: "list files"},
+							{Type: "debian.apt-get", Name: "list files"},
+							{Type: "credstash.lookup", Name: "list files"},
+							{Type: "debian.apt-get", Name: "list files"},
+							{Type: "debian.chmod", Name: "list files"},
+						},
+					},
 				},
 			},
 		},
@@ -34,69 +38,6 @@ func TestPlaybookListRequirements(t *testing.T) {
 		assert.Equal(t, tasks[1].Type, "debian.apt-get")
 		assert.Equal(t, tasks[2].Type, "credstash.lookup")
 		assert.Equal(t, tasks[3].Type, "debian.chmod")
-	})
-}
-
-func TestPlaybookTasksForRoles(t *testing.T) {
-	t.Run("list tasks for given roles", func(t *testing.T) {
-		playbook := Playbook{
-			Roles: []Role{
-				{
-					Name: "install_java",
-					Tasks: []Task{
-						{Type: "debian.apt-get", Name: "Install java"},
-					},
-				},
-				{
-					Name: "elastic_search",
-					Tasks: []Task{
-						{Type: "bash", Name: "list files"},
-						{Type: "credstash.lookup", Name: "list files"},
-					},
-					Dependents: []string{"install_java"},
-				},
-			},
-		}
-		roleNames := []string{"elastic_search"}
-		tasks, _ := playbook.TasksForRoles(roleNames)
-
-		if len(tasks) != 3 {
-			t.Errorf("Expected 3 tasks but got %d", len(tasks))
-			t.FailNow()
-		}
-
-		assert.Equal(t, tasks[0].Type, "debian.apt-get")
-		assert.Equal(t, tasks[1].Type, "bash")
-		assert.Equal(t, tasks[2].Type, "credstash.lookup")
-	})
-	t.Run("returns error if tasks have a dependency loop", func(t *testing.T) {
-		playbook := Playbook{
-			Roles: []Role{
-				{
-					Name: "install_java",
-					Tasks: []Task{
-						{Type: "debian.apt-get", Name: "Install java"},
-					},
-					Dependents: []string{"elastic_search"},
-				},
-				{
-					Name: "elastic_search",
-					Tasks: []Task{
-						{Type: "bash", Name: "list files"},
-						{Type: "credstash.lookup", Name: "list files"},
-					},
-					Dependents: []string{"install_java"},
-				},
-			},
-		}
-		roleNames := []string{"elastic_search"}
-		_, err := playbook.TasksForRoles(roleNames)
-
-		if err == nil {
-			t.Fatalf("expected and error but got none")
-		}
-
-		assert.Equal(t, err.Error(), "dependent Loop detected elastic_search > install_java > elastic_search")
 	})
 }
 

--- a/azad/role.go
+++ b/azad/role.go
@@ -1,6 +1,10 @@
 package azad
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+)
 
 // Roles collection of role's
 type Roles []Role
@@ -20,4 +24,5 @@ type Role struct {
 	Name       string
 	Dependents []string
 	Tasks      Tasks
+	Variables  map[string]cty.Value
 }

--- a/expect/array.go
+++ b/expect/array.go
@@ -1,0 +1,11 @@
+package expect
+
+import "testing"
+
+// EqualFatal asserts that length of 2 number are equal
+// if if fails it is raises a fatal
+func EqualFatal(t *testing.T, length, expected int, format ...string) {
+	if length != expected {
+		t.Fatalf("expected %d to equal %d", expected, length)
+	}
+}

--- a/parser/fixtures/basic.az
+++ b/parser/fixtures/basic.az
@@ -8,17 +8,29 @@ variable "elastic_search_role" {
   default = "elasticsearch"
 }
 
-variable "output_file" {
-  default = "azad.txt"
+variable "base_path" {
+  default = "/opt"
 }
 
 host "tag_kibana_server" {
   roles = [
     "${var.elastic_search_role}"
   ]
+
+  variable "install_path" {
+    default = "${var.base_path}/installer"
+  }
+
+  variable "home_path" {
+    default = "${var.base_path}/home"
+  }
 }
 
 role "elasticsearch" {
+  variable "ruby_install_path" {
+    default = "${var.install_path}/ruby"
+  }
+
   task "stat" "ruby-exists" {
     path = "/usr/bin/ruby"
   }
@@ -27,6 +39,4 @@ role "elasticsearch" {
     command = "echo \"does ruby exist ${ ruby-exists.exists }\" >> ${ var.output_file }"
     condition = "${not(ruby-exists.exists)}"
   }
-
-  dependents = ["java"]
 }

--- a/parser/fixtures/circular_dependents.az
+++ b/parser/fixtures/circular_dependents.az
@@ -1,0 +1,13 @@
+host "tag_kibana_server" {
+  roles = [
+    "elasticsearch"
+  ]
+}
+
+role "elasticsearch" {
+  dependents = ["java"]
+}
+
+role "java" {
+  dependents = ["elasticsearch"]
+}

--- a/parser/fixtures/roles_per_folder/basic.az
+++ b/parser/fixtures/roles_per_folder/basic.az
@@ -8,5 +8,9 @@ host "tag_kibana_server" {
   roles = [
     "ruby"
   ]
+
+  variable "home" {
+    default = "/home"
+  }
 }
 

--- a/parser/fixtures/roles_per_folder/roles/ruby/main.az
+++ b/parser/fixtures/roles_per_folder/roles/ruby/main.az
@@ -1,3 +1,9 @@
+dependents = ["security/firewall", "security/patches"]
+
+variable "install_path" {
+  default = "${var.home}/ruby"
+}
+
 task "apt-get.update" "update apt get" {
   user = "root"
 }

--- a/parser/fixtures/roles_per_folder/roles/security/firewall/main.az
+++ b/parser/fixtures/roles_per_folder/roles/security/firewall/main.az
@@ -1,3 +1,7 @@
+variable "next_path" {
+  default = "${var.home}/blah"
+}
+
 task "bash" "add-port" {
   command = "iptables.restore"
 }

--- a/parser/parse_playbook_with_circular_dependents_test.go
+++ b/parser/parse_playbook_with_circular_dependents_test.go
@@ -1,0 +1,25 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlaybookWithCircularDependents(t *testing.T) {
+	wd, _ := os.Getwd()
+	filePath := filepath.Join(wd, "fixtures", "circular_dependents.az")
+	env := map[string]string{
+		"user":      "bruce_banner",
+		"home_path": "/home/bruce_banner",
+	}
+
+	_, err := PlaybookFromFile(filePath, env)
+
+	if err == nil {
+		t.Fatalf("Expected but got none")
+	}
+	assert.Equal(t, err.Error(), "1 error occurred:\n\n* dependent Loop detected elasticsearch > java > elasticsearch")
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -20,9 +20,9 @@ func PlaybookFromFile(path string, env map[string]string) (azad.Playbook, error)
 	if err != nil {
 		errors = multierror.Append(errors, err)
 	}
-	variables, err := unpackVariables(playbookDescription.Variables)
+	variables, err := unpackVariables(playbookDescription.Variables, evalContext)
 	if err != nil {
-		errors = multierror.Append(errors, err)
+		return azad.Playbook{}, err
 	}
 	if len(variables) == 0 {
 		evalContext.Variables["var"] = cty.MapValEmpty(cty.String)
@@ -37,11 +37,7 @@ func PlaybookFromFile(path string, env map[string]string) (azad.Playbook, error)
 	if err != nil {
 		errors = multierror.Append(errors, err)
 	}
-	hosts, err := unpackHosts(playbookDescription.Hosts, evalContext)
-	if err != nil {
-		errors = multierror.Append(errors, err)
-	}
-	roles, err := unpackRoles(playbookDescription.roleDescriptionGroups, evalContext)
+	hosts, err := unpackHosts(playbookDescription.Hosts, playbookDescription.roleDescriptionGroups, evalContext)
 	if err != nil {
 		errors = multierror.Append(errors, err)
 	}
@@ -49,7 +45,7 @@ func PlaybookFromFile(path string, env map[string]string) (azad.Playbook, error)
 		Inventories: inventories,
 		Servers:     servers,
 		Hosts:       hosts,
-		Roles:       roles,
+		Variables:   variables,
 	}, errors.ErrorOrNil()
 }
 

--- a/parser/playbook_description.go
+++ b/parser/playbook_description.go
@@ -26,6 +26,6 @@ type serverDescription struct {
 
 // Variable value
 type variableDescription struct {
-	Name    string `hcl:",label"`
-	Default string `hcl:"default"`
+	Name   string   `hcl:",label"`
+	Config hcl.Body `hcl:",remain"`
 }

--- a/parser/role_description.go
+++ b/parser/role_description.go
@@ -17,6 +17,27 @@ func (roleDescriptionGroups roleDescriptionGroups) RoleFor(name string) (roleDes
 	return roleDescriptionGroup{}, fmt.Errorf("role with name %s not found", name)
 }
 
+func (roleDescriptionGroups roleDescriptionGroups) FilterMany(names []string) (roleDescriptionGroups, error) {
+	filteredRoleDescriptionGroups := []roleDescriptionGroup{}
+	for _, name := range names {
+		roleDescriptionGroup, err := roleDescriptionGroups.Filter(name)
+		if err != nil {
+			return roleDescriptionGroups, err
+		}
+		filteredRoleDescriptionGroups = append(filteredRoleDescriptionGroups, roleDescriptionGroup)
+	}
+	return filteredRoleDescriptionGroups, nil
+}
+
+func (roleDescriptionGroups roleDescriptionGroups) Filter(name string) (roleDescriptionGroup, error) {
+	for _, roleDescriptionGroup := range roleDescriptionGroups {
+		if roleDescriptionGroup.name == name {
+			return roleDescriptionGroup, nil
+		}
+	}
+	return roleDescriptionGroup{}, fmt.Errorf("role description group not found")
+}
+
 func (roleDescriptionGroups roleDescriptionGroups) ReplaceWith(role roleDescriptionGroup) {
 	for i, roleDescriptionGroup := range roleDescriptionGroups {
 		if roleDescriptionGroup.name == role.name {
@@ -48,9 +69,10 @@ type roleDescriptions []roleDescription
 
 // Role list of task to be applied to host
 type roleDescription struct {
-	Name       string   `hcl:",label"`
-	Dependents []string `hcl:"dependents,optional"`
-	Config     hcl.Body `hcl:",remain"`
+	Name       string                `hcl:",label"`
+	Dependents []string              `hcl:"dependents,optional"`
+	Variables  []variableDescription `hcl:"variable,block"`
+	Config     hcl.Body              `hcl:",remain"`
 }
 
 // Task run command via ssh

--- a/parser/role_description_test.go
+++ b/parser/role_description_test.go
@@ -1,0 +1,77 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/pythonandchips/azad/expect"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoleDescriptioGroups(t *testing.T) {
+	roleDescriptionGroups := roleDescriptionGroups{
+		{name: "ruby"},
+		{name: "java"},
+		{name: "erlang"},
+	}
+	t.Run("RoleFor", func(t *testing.T) {
+		t.Run("returns roleDescription group when role exists in group", func(t *testing.T) {
+			roleDescriptionGroup, err := roleDescriptionGroups.RoleFor("ruby")
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			assert.Equal(t, roleDescriptionGroup.name, "ruby")
+		})
+		t.Run("error when role does not exist", func(t *testing.T) {
+			_, err := roleDescriptionGroups.RoleFor("nginx")
+			if err == nil {
+				t.Fatalf("expected error but none returned")
+			}
+		})
+	})
+	t.Run("FilterMany", func(t *testing.T) {
+		t.Run("returns all matching roleDescriptionGroup", func(t *testing.T) {
+			matchingRoleDescriptionGroup, err := roleDescriptionGroups.FilterMany([]string{"ruby", "java"})
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			expect.EqualFatal(t, len(matchingRoleDescriptionGroup), 2)
+		})
+		t.Run("returns error of any name cannot be matched", func(t *testing.T) {
+			_, err := roleDescriptionGroups.FilterMany([]string{"ruby", "elm"})
+			if err == nil {
+				t.Fatalf("expected error but none returned")
+			}
+		})
+	})
+	t.Run("Filter", func(t *testing.T) {
+		t.Run("returns matching roleDescriptionGroup", func(t *testing.T) {
+			matchingRoleDescriptionGroup, err := roleDescriptionGroups.Filter("ruby")
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			assert.Equal(t, matchingRoleDescriptionGroup.name, "ruby")
+		})
+		t.Run("returns error if roleDescriptionGroup not found", func(t *testing.T) {
+			_, err := roleDescriptionGroups.Filter("elm")
+			if err == nil {
+				t.Fatalf("Expected error but none returned")
+			}
+		})
+	})
+	t.Run("ReplaceWith", func(t *testing.T) {
+		t.Run("replaces the role with matching name", func(t *testing.T) {
+			updatedRoleDescriptionGroup := roleDescriptionGroup{
+				name: "java",
+				files: []roleFile{
+					{name: "main"},
+				},
+			}
+
+			roleDescriptionGroups.ReplaceWith(updatedRoleDescriptionGroup)
+
+			expect.EqualFatal(t, len(roleDescriptionGroups), 3)
+
+			assert.Equal(t, len(updatedRoleDescriptionGroup.files), len(roleDescriptionGroups[1].files))
+		})
+	})
+}

--- a/parser/unpack_roles.go
+++ b/parser/unpack_roles.go
@@ -6,68 +6,94 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/pythonandchips/azad/azad"
+	"github.com/zclconf/go-cty/cty"
 )
 
-func unpackRoles(roleDescriptionGroups roleDescriptionGroups, evalContext *hcl.EvalContext) ([]azad.Role, error) {
+func unpackRoles(
+	roleDescriptionGroups roleDescriptionGroups,
+	evalContext *hcl.EvalContext,
+) ([]azad.Role, error) {
 	errors := &multierror.Error{}
 	roles := []azad.Role{}
 	for _, roleDescriptionGroup := range roleDescriptionGroups {
-		role := azad.Role{
-			Name: roleDescriptionGroup.name,
-		}
-		tasks, dependents, err := unpackTasksForRole(
-			"main",
-			roleDescriptionGroup,
-			evalContext,
-		)
+		role, err := unpackRole(roleDescriptionGroup, evalContext)
 		if err != nil {
 			errors = multierror.Append(errors, err)
-			continue
 		}
-		role.Dependents = append(role.Dependents, dependents...)
-		role.Tasks = tasks
 		roles = append(roles, role)
 	}
 	return roles, errors.ErrorOrNil()
+}
+
+func unpackRole(
+	roleDescriptionGroup roleDescriptionGroup,
+	evalContext *hcl.EvalContext,
+) (azad.Role, error) {
+	role := azad.Role{
+		Name:      roleDescriptionGroup.name,
+		Variables: map[string]cty.Value{},
+	}
+	err := unpackTasksForRole(
+		"main",
+		roleDescriptionGroup,
+		evalContext,
+		&role,
+	)
+	if err != nil {
+		return role, err
+	}
+	return role, nil
 }
 
 func unpackTasksForRole(
 	file string,
 	roleDescriptionGroup roleDescriptionGroup,
 	evalContext *hcl.EvalContext,
-) ([]azad.Task, []string, error) {
-	tasks := []azad.Task{}
+	role *azad.Role,
+) error {
+	roleContext := newChildContext(evalContext)
 	mainFile, err := roleDescriptionGroup.findFile(file)
 	if err != nil {
-		return tasks, []string{}, fmt.Errorf("cannot find main file for role %s", roleDescriptionGroup.name)
+		return fmt.Errorf("cannot find main file for role %s", roleDescriptionGroup.name)
 	}
 	roleDescription := mainFile.roleDescription
 	dependents := roleDescription.Dependents
+	variables, err := unpackVariables(roleDescription.Variables, roleContext)
+	if err != nil {
+		return err
+	}
 	roleSchema := roleSchema()
 	content, configErr := roleDescription.Config.Content(&roleSchema)
 	if configErr.HasErrors() {
-		return tasks, []string{}, fmt.Errorf("unable to parse role config: %s", err.Error())
+		return fmt.Errorf("unable to parse role config: %s", configErr.Error())
 	}
 	errors := &multierror.Error{}
 	for _, block := range content.Blocks {
 		switch block.Type {
 		case "include":
-			include := unpackInclude(block, evalContext)
-			includeTasks, includeDependents, err := unpackTasksForRole(include, roleDescriptionGroup, evalContext)
+			include := unpackInclude(block, roleContext)
+			err := unpackTasksForRole(include, roleDescriptionGroup, roleContext, role)
 			if err != nil {
 				errors = multierror.Append(errors, err)
 				continue
 			}
-			tasks = append(tasks, includeTasks...)
-			dependents = append(dependents, includeDependents...)
 		case "task":
-			task, _ := unpackTask(block, evalContext)
-			tasks = append(tasks, task)
+			task, _ := unpackTask(block, roleContext)
+			role.Tasks = append(role.Tasks, task)
 		default:
 			errors = multierror.Append(errors, fmt.Errorf("unrecognized block %s in %s/%s.az", block.Type, roleDescriptionGroup.name, file))
 		}
 	}
-	return tasks, dependents, nil
+	role.Dependents = append(role.Dependents, dependents...)
+	role.Variables = mergeMap(role.Variables, variables)
+	return nil
+}
+
+func mergeMap(existing, new map[string]cty.Value) map[string]cty.Value {
+	for key, value := range new {
+		existing[key] = value
+	}
+	return existing
 }
 
 func unpackInclude(body *hcl.Block, evalContext *hcl.EvalContext) string {
@@ -103,6 +129,7 @@ func roleSchema() hcl.BodySchema {
 		Blocks: []hcl.BlockHeaderSchema{
 			{Type: "include"},
 			{Type: "task", LabelNames: []string{"command", "label"}},
+			{Type: "variable", LabelNames: []string{"name"}},
 		},
 	}
 	return roleSchema

--- a/parser/unpack_variables.go
+++ b/parser/unpack_variables.go
@@ -1,11 +1,48 @@
 package parser
 
-import "github.com/zclconf/go-cty/cty"
+import (
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
 
-func unpackVariables(variableDescriptions []variableDescription) (map[string]cty.Value, error) {
+func unpackVariables(variableDescriptions []variableDescription, evalContext *hcl.EvalContext) (map[string]cty.Value, error) {
 	variables := map[string]cty.Value{}
+	variableSchema := variableSchema()
+	errors := &multierror.Error{}
 	for _, variableDescription := range variableDescriptions {
-		variables[variableDescription.Name] = cty.StringVal(variableDescription.Default)
+		variableSource, err := variableDescription.Config.Content(&variableSchema)
+		if err != nil {
+			errors = multierror.Append(errors, err)
+			continue
+		}
+		if attr, ok := variableSource.Attributes["default"]; ok {
+			val, err := attr.Expr.Value(evalContext)
+			if err != nil {
+				errors = multierror.Append(errors, err)
+				continue
+			}
+			variables[variableDescription.Name] = val
+			contextVars := evalContext.Variables["var"]
+			vars := map[string]cty.Value{}
+			if !contextVars.IsNull() {
+				vars = contextVars.AsValueMap()
+			}
+			if len(vars) == 0 {
+				vars = map[string]cty.Value{}
+			}
+			vars[variableDescription.Name] = val
+			evalContext.Variables["var"] = cty.MapVal(vars)
+		}
 	}
-	return variables, nil
+	return variables, errors.ErrorOrNil()
+}
+
+func variableSchema() hcl.BodySchema {
+	hostSchema := hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: "default", Required: true},
+		},
+	}
+	return hostSchema
 }

--- a/runner/helpers_test.go
+++ b/runner/helpers_test.go
@@ -1,0 +1,35 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/pythonandchips/azad/conn"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func RunnerEquals(t *testing.T, runner *runner, address string, variables map[string]cty.Value) {
+	conn, _ := runner.Conn.(*fakeConn)
+	assert.Equal(t, runner.Address, address)
+	assert.Equal(t, runner.GlobalVariables, variables)
+	assert.Equal(t, conn.ConnectedTo, address)
+}
+
+type fakeConn struct {
+	ConnectedTo     string
+	ConnectionError error
+	Closed          bool
+}
+
+func (fakeConn *fakeConn) ConnectTo(ip string) error {
+	fakeConn.ConnectedTo = ip
+	return fakeConn.ConnectionError
+}
+
+func (fakeConn *fakeConn) Run(conn.Command) (conn.Response, error) {
+	return conn.CommandResponse{}, nil
+}
+
+func (fakeConn *fakeConn) Close() {
+	fakeConn.Closed = true
+}

--- a/runner/run_playbook.go
+++ b/runner/run_playbook.go
@@ -1,10 +1,8 @@
 package runner
 
 import (
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pythonandchips/azad/azad"
 	"github.com/pythonandchips/azad/communicator"
-	"github.com/pythonandchips/azad/conn"
 	"github.com/pythonandchips/azad/logger"
 	"github.com/pythonandchips/azad/parser"
 )
@@ -31,50 +29,23 @@ var RunPlaybook = func(playbookFilePath string, globalConfig azad.Config) {
 	}
 	for _, host := range playbook.Hosts {
 		logger.Info("Running for %s", host.ServerGroup)
-		tasks, err := playbook.TasksForRoles(host.Roles)
 
 		if err != nil {
 			logger.ErrorAndExit("%s", err)
 		}
 
 		server, _ := playbook.LookupServer(host.ServerGroup)
-		runners, err := createRunners(server.Addresses)
+		runners, err := createRunners(server.Addresses, mergeVariables(playbook.Variables, host.Variables))
 		defer runners.Close()
 		if err != nil {
 			logger.Error("%s", err)
 			return
 		}
-		runTasks(tasks, runners)
-		logger.Info("Finished Applying %s", host.ServerGroup)
-	}
-}
-
-func createRunners(addresses []string) (runners, error) {
-	runners := runners{}
-	errors := &multierror.Error{}
-	for _, address := range addresses {
-		connection := conn.NewConn(config.SSHConfig())
-		err := connection.ConnectTo(address)
-		if err != nil {
-			errors = multierror.Append(errors, err)
-			break
-		}
-		runner := newRunner(connection, address)
-		runners = append(runners, runner)
-	}
-	return runners, errors.ErrorOrNil()
-}
-
-// ValidatePlugins validate that all plugins and tasks are available
-func validatePlugins(playbook azad.Playbook) error {
-	errors := &multierror.Error{}
-	tasks := playbook.RequiredTasks()
-	for _, task := range tasks {
-		if _, err := communicator.GetTask(task.PluginName(), task.TaskName()); err != nil {
-			errors = multierror.Append(errors, err)
+		for _, role := range host.Roles {
+			runTasks(role.Tasks, runners.ChildRunners(role.Variables))
+			logger.Info("Finished Applying %s", host.ServerGroup)
 		}
 	}
-	return errors.ErrorOrNil()
 }
 
 func runTasks(tasks azad.Tasks, runners runners) error {

--- a/runner/run_task_test.go
+++ b/runner/run_task_test.go
@@ -7,9 +7,11 @@ import (
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/pythonandchips/azad/azad"
+	"github.com/pythonandchips/azad/expect"
 	"github.com/pythonandchips/azad/logger"
 	"github.com/pythonandchips/azad/plugin"
 	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestRunTask(t *testing.T) {
@@ -27,8 +29,8 @@ func TestRunTask(t *testing.T) {
 				"exists": "true",
 			},
 		},
-		Variables: map[string]string{
-			"dynamic_value": "dvalue",
+		GlobalVariables: map[string]cty.Value{
+			"dynamic_value": cty.StringVal("dvalue"),
 		},
 	}
 	t.Run("with a successful task", func(t *testing.T) {
@@ -69,7 +71,7 @@ func TestRunTask(t *testing.T) {
 			assert.Equal(t, ok, true, "expected varaibles to contain %s", "nil-task")
 		})
 		t.Run("writes output to log", func(t *testing.T) {
-			assertLengthFatal(t, len(testLogger.Lines), 2)
+			expect.EqualFatal(t, len(testLogger.Lines), 2)
 			assert.Equal(t, testLogger.Lines[0], "INFO: Applying nil-task:nil-task on 10.0.0.1\n")
 			assert.Equal(t, testLogger.Lines[1], "INFO: Success nil-task:nil-task on 10.0.0.1\n")
 		})
@@ -128,11 +130,5 @@ func testExpression(name, value string) *hcl.Attribute {
 	}
 	return &hcl.Attribute{
 		Name: name, Expr: expr,
-	}
-}
-
-func assertLengthFatal(t *testing.T, length, expected int) {
-	if length != expected {
-		t.Fatalf("expected %d log lines but got %d", expected, length)
 	}
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,0 +1,50 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestRunnerNewChild(t *testing.T) {
+	runner := &runner{
+		Address: "10.0.0.1",
+		Conn:    &fakeConn{Closed: false},
+		GlobalVariables: map[string]cty.Value{
+			"install_dir": cty.StringVal("/opt"),
+		},
+	}
+	childVariables := map[string]cty.Value{
+		"install_ruby": cty.StringVal("/opt/ruby"),
+	}
+	childRunner := runner.newChild(childVariables)
+
+	assert.Equal(t, childRunner.GlobalVariables["install_dir"].AsString(), "/opt")
+	assert.Equal(t, childRunner.GlobalVariables["install_ruby"].AsString(), "/opt/ruby")
+	assert.Equal(t, childRunner.Address, runner.Address)
+	assert.Equal(t, childRunner.Conn, runner.Conn)
+}
+
+func TestRunnerToContext(t *testing.T) {
+	runner := &runner{
+		Address: "10.0.0.1",
+		Conn:    &fakeConn{Closed: false},
+		GlobalVariables: map[string]cty.Value{
+			"install_dir": cty.StringVal("/opt"),
+		},
+		taskResults: map[string]taskResult{
+			"ruby.install": taskResult{
+				"success": "true",
+			},
+		},
+	}
+	context := runner.toContext()
+
+	varValue := context["var"].AsValueMap()
+	assert.Equal(t, varValue["install_dir"].AsString(), "/opt")
+
+	rubyInstallResult := context["ruby.install"].AsValueMap()
+	assert.Equal(t, rubyInstallResult["success"].AsString(), "true")
+
+}

--- a/runner/runners.go
+++ b/runner/runners.go
@@ -1,0 +1,43 @@
+package runner
+
+import (
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/pythonandchips/azad/conn"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type runners []*runner
+
+var newConn = func(config conn.Config) conn.Conn {
+	return conn.NewConn(config)
+}
+
+func createRunners(addresses []string, variables map[string]cty.Value) (runners, error) {
+	runners := runners{}
+	errors := &multierror.Error{}
+	for _, address := range addresses {
+		connection := newConn(config.SSHConfig())
+		err := connection.ConnectTo(address)
+		if err != nil {
+			errors = multierror.Append(errors, err)
+			break
+		}
+		runner := newRunner(connection, address, variables)
+		runners = append(runners, runner)
+	}
+	return runners, errors.ErrorOrNil()
+}
+
+func (runners runners) Close() {
+	for _, runner := range runners {
+		runner.Conn.Close()
+	}
+}
+
+func (runners runners) ChildRunners(variables map[string]cty.Value) runners {
+	childRunners := []*runner{}
+	for _, runner := range runners {
+		childRunners = append(childRunners, runner.newChild(variables))
+	}
+	return childRunners
+}

--- a/runner/runners_test.go
+++ b/runner/runners_test.go
@@ -1,0 +1,76 @@
+package runner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pythonandchips/azad/conn"
+	"github.com/pythonandchips/azad/expect"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCreateRunners(t *testing.T) {
+	addresses := []string{"10.0.0.1", "10.0.0.2"}
+	variables := map[string]cty.Value{
+		"install_dir": cty.StringVal("/opt"),
+	}
+	t.Run("when connection can be made to address", func(t *testing.T) {
+		newConn = func(config conn.Config) conn.Conn {
+			return &fakeConn{}
+		}
+		runners, err := createRunners(addresses, variables)
+		if err != nil {
+			t.Fatalf("Unexpected Error: %s", err)
+		}
+		t.Run("creates runners for addresses", func(t *testing.T) {
+			expect.EqualFatal(t, len(runners), 2)
+			RunnerEquals(t, runners[0], "10.0.0.1", variables)
+			RunnerEquals(t, runners[1], "10.0.0.2", variables)
+		})
+	})
+	t.Run("when connection cannot be made to server an error is returned", func(t *testing.T) {
+		newConn = func(config conn.Config) conn.Conn {
+			return &fakeConn{ConnectionError: fmt.Errorf("unable to connect")}
+		}
+		_, err := createRunners(addresses, variables)
+		if err == nil {
+			t.Fatalf("Expected error but got none")
+		}
+	})
+}
+
+func TestRunnersChildRunners(t *testing.T) {
+	runner := &runner{
+		Address: "10.0.0.1",
+		Conn:    &fakeConn{Closed: false},
+		GlobalVariables: map[string]cty.Value{
+			"install_dir": cty.StringVal("/opt"),
+		},
+	}
+	runners := runners{runner}
+	childVariables := map[string]cty.Value{
+		"install_ruby": cty.StringVal("/opt/ruby"),
+	}
+	childRunners := runners.ChildRunners(childVariables)
+	expect.EqualFatal(t, len(childRunners), 1)
+
+	childRunner := childRunners[0]
+
+	assert.Equal(t, childRunner.GlobalVariables["install_dir"].AsString(), "/opt")
+	assert.Equal(t, childRunner.GlobalVariables["install_ruby"].AsString(), "/opt/ruby")
+	assert.Equal(t, childRunner.Address, runner.Address)
+	assert.Equal(t, childRunner.Conn, runner.Conn)
+}
+
+func TestRunnersClose(t *testing.T) {
+	runners := runners{
+		&runner{Address: "10.0.0.1", Conn: &fakeConn{Closed: false}},
+		&runner{Address: "10.0.0.2", Conn: &fakeConn{Closed: false}},
+	}
+	runners.Close()
+	t.Run("closes all connections", func(t *testing.T) {
+		assert.True(t, runners[0].Conn.(*fakeConn).Closed)
+		assert.True(t, runners[1].Conn.(*fakeConn).Closed)
+	})
+}

--- a/runner/validate_plugin.go
+++ b/runner/validate_plugin.go
@@ -1,0 +1,19 @@
+package runner
+
+import (
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/pythonandchips/azad/azad"
+	"github.com/pythonandchips/azad/communicator"
+)
+
+// ValidatePlugins validate that all plugins and tasks are available
+func validatePlugins(playbook azad.Playbook) error {
+	errors := &multierror.Error{}
+	tasks := playbook.RequiredTasks()
+	for _, task := range tasks {
+		if _, err := communicator.GetTask(task.PluginName(), task.TaskName()); err != nil {
+			errors = multierror.Append(errors, err)
+		}
+	}
+	return errors.ErrorOrNil()
+}

--- a/runner/variables.go
+++ b/runner/variables.go
@@ -1,0 +1,13 @@
+package runner
+
+import "github.com/zclconf/go-cty/cty"
+
+func mergeVariables(vars ...map[string]cty.Value) map[string]cty.Value {
+	variables := map[string]cty.Value{}
+	for _, variableSet := range vars {
+		for key, value := range variableSet {
+			variables[key] = value
+		}
+	}
+	return variables
+}


### PR DESCRIPTION
Scope variables to host and roles

Host and roles now have there own variable set an hosts are now unpacked
as a child of role.

Roles now contain there own variables

Parse variables based on roles. Roles can access variables from the host
but not other roles.

In order to keep scope variables for each role create a child scope for
each role. A child scope contains the merge of the parent global
variables with the variables for the role.

Initial runner variables are are a merge of playbook variables and role
variables

Resolves #17 