### PR TITLE
Make root and role path available to task

### DIFF
--- a/azad/playbook.go
+++ b/azad/playbook.go
@@ -13,6 +13,7 @@ type Playbook struct {
 	Servers     []Server
 	Hosts       []Host
 	Variables   map[string]cty.Value
+	Path        string
 }
 
 // LookupServer lookup server

--- a/azad/role.go
+++ b/azad/role.go
@@ -25,4 +25,5 @@ type Role struct {
 	Dependents []string
 	Tasks      Tasks
 	Variables  map[string]cty.Value
+	Path       string
 }

--- a/parser/load_config.go
+++ b/parser/load_config.go
@@ -161,6 +161,7 @@ func createRoleDescriptionGroupFromFolder(rolesFolderPath, path string) (roleDes
 	}
 	roleDescriptionGroup := roleDescriptionGroup{
 		name: roleName,
+		path: path,
 	}
 	return roleDescriptionGroup, nil
 }

--- a/parser/parse_roles_per_folder_test.go
+++ b/parser/parse_roles_per_folder_test.go
@@ -11,10 +11,11 @@ import (
 
 func TestParseRolesPerFolder(t *testing.T) {
 	wd, _ := os.Getwd()
-	filePath := filepath.Join(wd, "fixtures", "roles_per_folder", "basic.az")
+	filePath := filepath.Join(wd, "fixtures", "roles_per_folder")
+	playbookPath := filepath.Join(filePath, "basic.az")
 	env := map[string]string{}
 
-	playbook, err := PlaybookFromFile(filePath, env)
+	playbook, err := PlaybookFromFile(playbookPath, env)
 
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
@@ -55,6 +56,8 @@ func TestParseRolesPerFolder(t *testing.T) {
 
 			t.Run("parse dependent roles", func(t *testing.T) {
 				role := roles[0]
+				rolePath := filepath.Join(filePath, "roles", "security", "firewall")
+				assert.Equal(t, role.Path, rolePath)
 
 				assert.Equal(t, len(role.Tasks), 1)
 				assert.Equal(t, len(role.Variables), 1)
@@ -62,6 +65,8 @@ func TestParseRolesPerFolder(t *testing.T) {
 
 			t.Run("parses tasks for role", func(t *testing.T) {
 				rubyRole := roles[2]
+				rolePath := filepath.Join(filePath, "roles", "ruby")
+				assert.Equal(t, rubyRole.Path, rolePath)
 
 				assert.Equal(t, len(rubyRole.Tasks), 3)
 			})

--- a/parser/role_description.go
+++ b/parser/role_description.go
@@ -49,6 +49,7 @@ func (roleDescriptionGroups roleDescriptionGroups) ReplaceWith(role roleDescript
 type roleDescriptionGroup struct {
 	name  string
 	files []roleFile
+	path  string
 }
 
 func (roleDescriptionGroup roleDescriptionGroup) findFile(name string) (roleFile, error) {

--- a/parser/unpack_roles.go
+++ b/parser/unpack_roles.go
@@ -32,6 +32,7 @@ func unpackRole(
 	role := azad.Role{
 		Name:      roleDescriptionGroup.name,
 		Variables: map[string]cty.Value{},
+		Path:      roleDescriptionGroup.path,
 	}
 	err := unpackTasksForRole(
 		"main",

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -5,10 +5,12 @@ import (
 )
 
 // NewContext create a new context for passing to a plugin to run a task
-func NewContext(vars map[string]string, conn conn.Conn) Context {
+func NewContext(vars map[string]string, conn conn.Conn, rootPath, rolePath string) Context {
 	return Context{
-		vars: vars,
-		conn: conn,
+		vars:     vars,
+		conn:     conn,
+		rootPath: rootPath,
+		rolePath: rolePath,
 	}
 }
 
@@ -21,11 +23,13 @@ func NewInventoryContext(vars map[string]string) Context {
 
 // Context for task run. Main representation of data for task run
 type Context struct {
-	conn   conn.Conn
-	vars   map[string]string
-	env    map[string]string
-	stdout string
-	stderr string
+	conn     conn.Conn
+	vars     map[string]string
+	env      map[string]string
+	stdout   string
+	stderr   string
+	rolePath string
+	rootPath string
 }
 
 // Run command against the ssh connection for the server
@@ -63,4 +67,14 @@ func (context Context) GetWithDefault(key, def string) string {
 		return def
 	}
 	return val
+}
+
+// PlaybookRoot absolute path to root of running playbook
+func (context Context) PlaybookRoot() string {
+	return context.rootPath
+}
+
+// RoleRoot absolute path to root of running role
+func (context Context) RoleRoot() string {
+	return context.rolePath
 }

--- a/runner/run_playbook.go
+++ b/runner/run_playbook.go
@@ -42,17 +42,24 @@ var RunPlaybook = func(playbookFilePath string, globalConfig azad.Config) {
 			return
 		}
 		for _, role := range host.Roles {
-			runTasks(role.Tasks, runners.ChildRunners(role.Variables))
+			runTasks(role.Tasks, runners.ChildRunners(role.Variables), role.Path, playbook.Path)
 			logger.Info("Finished Applying %s", host.ServerGroup)
 		}
 	}
 }
 
-func runTasks(tasks azad.Tasks, runners runners) error {
+func runTasks(tasks azad.Tasks, runners runners, rootPath, rolePath string) error {
 	for _, task := range tasks {
 		taskSchema, _ := communicator.GetTask(task.PluginName(), task.TaskName())
 		for _, runner := range runners {
-			runTask(task, taskSchema, runner)
+			runTaskParams := runTaskParams{
+				task:       task,
+				taskSchema: taskSchema,
+				runner:     runner,
+				rootPath:   rootPath,
+				rolePath:   rolePath,
+			}
+			runTask(runTaskParams)
 		}
 	}
 	return nil

--- a/runner/run_task.go
+++ b/runner/run_task.go
@@ -1,44 +1,100 @@
 package runner
 
 import (
+	"errors"
+
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/pythonandchips/azad/azad"
+	"github.com/pythonandchips/azad/conn"
 	"github.com/pythonandchips/azad/logger"
 	"github.com/pythonandchips/azad/plugin"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
 
-func runTask(task azad.Task, taskSchema plugin.Task, runner *runner) error {
-	logger.Info("Applying %s:%s on %s", task.Type, task.Name, runner.Address)
+type runTaskParams struct {
+	task       azad.Task
+	taskSchema plugin.Task
+	runner     *runner
+	rootPath   string
+	rolePath   string
+}
+
+func (runTaskParams runTaskParams) Type() string {
+	return runTaskParams.task.Type
+}
+
+func (runTaskParams runTaskParams) Name() string {
+	return runTaskParams.task.Name
+}
+
+func (runTaskParams runTaskParams) Address() string {
+	return runTaskParams.runner.Address
+}
+
+func (runTaskParams runTaskParams) toContext() map[string]cty.Value {
+	return runTaskParams.runner.toContext()
+}
+
+func (runTaskParams runTaskParams) conditionResult(evalContext *hcl.EvalContext) (cty.Value, error) {
+	value, err := runTaskParams.task.Condition.Expr.Value(evalContext)
+	if err.HasErrors() {
+		return value, errors.New(err.Error())
+	}
+	return value, nil
+}
+
+func (runTaskParams runTaskParams) conn() conn.Conn {
+	return runTaskParams.runner.Conn
+}
+
+func (runTaskParams runTaskParams) run(context plugin.Context) (map[string]string, error) {
+	return runTaskParams.taskSchema.Run(context)
+}
+
+func (runTaskParams runTaskParams) logParmas() []interface{} {
+	return []interface{}{
+		runTaskParams.Type(),
+		runTaskParams.Name(),
+		runTaskParams.Address(),
+	}
+}
+
+func runTask(runTaskParams runTaskParams) error {
+	logger.Info("Applying %s:%s on %s", runTaskParams.logParmas()...)
 	evalContext := &hcl.EvalContext{
-		Variables: runner.toContext(),
+		Variables: runTaskParams.toContext(),
 		Functions: stdFunctions(),
 	}
-	if task.Condition != nil {
-		result, err := task.Condition.Expr.Value(evalContext)
+	if runTaskParams.task.Condition != nil {
+		result, err := runTaskParams.conditionResult(evalContext)
 		if err != nil {
-			logger.Error("Error evaluating conditional %s:%s on %s: %s", task.Type, task.Name, runner.Address, err)
+			logger.Error("Error evaluating conditional %s:%s on %s: %s", runTaskParams.logParmas()...)
 			return err
 		}
 		if result.True() {
-			logger.Info("Skipping %s:%s on %s, condition failed", task.Type, task.Name, runner.Address)
+			logger.Info("Skipping %s:%s on %s, condition failed", runTaskParams.logParmas()...)
 			return nil
 		}
 	}
-	vars, err := varsForTask(taskSchema.Fields, task, evalContext)
+	vars, err := varsForTask(runTaskParams.taskSchema.Fields, runTaskParams.task, evalContext)
 	if err != nil {
 		return err
 	}
-	context := plugin.NewContext(vars, runner.Conn)
-	results, err := taskSchema.Run(context)
+	context := plugin.NewContext(
+		vars,
+		runTaskParams.conn(),
+		runTaskParams.rootPath,
+		runTaskParams.rolePath,
+	)
+	results, err := runTaskParams.run(context)
 	if err != nil {
-		logger.Error("Failed %s:%s on %s", task.Type, task.Name, runner.Address)
+		logger.Error("Failed %s:%s on %s", runTaskParams.logParmas()...)
 		logger.Error("Error: %s", err)
 		return err
 	}
-	runner.setResult(task.Name, results)
-	logger.Info("Success %s:%s on %s", task.Type, task.Name, runner.Address)
+	runTaskParams.runner.setResult(runTaskParams.Name(), results)
+	logger.Info("Success %s:%s on %s", runTaskParams.logParmas()...)
 	return nil
 }
 

--- a/runner/run_task_test.go
+++ b/runner/run_task_test.go
@@ -57,7 +57,14 @@ func TestRunTask(t *testing.T) {
 				"other_task_value": testExpression("other_task_value", "${ previous_result.ok }"),
 			},
 		}
-		err := runTask(task, pluginTask, runner)
+		runTaskParams := runTaskParams{
+			task:       task,
+			taskSchema: pluginTask,
+			runner:     runner,
+			rootPath:   "/home/azad/root",
+			rolePath:   "/home/azad/root/roles/a_role",
+		}
+		err := runTask(runTaskParams)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -69,6 +76,10 @@ func TestRunTask(t *testing.T) {
 		t.Run("adds the new variables to the runners variables", func(t *testing.T) {
 			_, ok := runner.taskResults["nil-task"]
 			assert.Equal(t, ok, true, "expected varaibles to contain %s", "nil-task")
+		})
+		t.Run("it sets the available file paths", func(t *testing.T) {
+			assert.Equal(t, suppliedContext.PlaybookRoot(), "/home/azad/root")
+			assert.Equal(t, suppliedContext.RoleRoot(), "/home/azad/root/roles/a_role")
 		})
 		t.Run("writes output to log", func(t *testing.T) {
 			expect.EqualFatal(t, len(testLogger.Lines), 2)
@@ -89,7 +100,12 @@ func TestRunTask(t *testing.T) {
 			Name:       "failing-task",
 			Attributes: map[string]*hcl.Attribute{},
 		}
-		err := runTask(failingTask, failingPluginTask, runner)
+		runTaskParams := runTaskParams{
+			task:       failingTask,
+			taskSchema: failingPluginTask,
+			runner:     runner,
+		}
+		err := runTask(runTaskParams)
 		if err == nil {
 			t.Fatalf("expected an error but got none")
 		}
@@ -113,7 +129,12 @@ func TestRunTask(t *testing.T) {
 			Attributes: map[string]*hcl.Attribute{},
 			Condition:  testExpression("condition", "${not(ruby-exists.exists)}"),
 		}
-		err := runTask(conditionalTask, conditionalPluginTask, runner)
+		runTaskParams := runTaskParams{
+			task:       conditionalTask,
+			taskSchema: conditionalPluginTask,
+			runner:     runner,
+		}
+		err := runTask(runTaskParams)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}


### PR DESCRIPTION
Some task will need to access files on the local drive. This can be for
a template to generate a file or to copy a file to the server.

The paths are made available via `Context.PlaybookPath` and
`Context.RolePath`

Resolves #29 