### PR TITLE
Add user as a default task argument

### DIFF
--- a/plugin/command.go
+++ b/plugin/command.go
@@ -8,6 +8,4 @@ type Command struct {
 	Command []string
 	// Additional environment variable to be used in the command
 	Env map[string]string
-	// User to run the command with e.g. root, admin
-	User string
 }

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -5,10 +5,11 @@ import (
 )
 
 // NewContext create a new context for passing to a plugin to run a task
-func NewContext(vars map[string]string, conn conn.Conn, rootPath, rolePath string) Context {
+func NewContext(vars map[string]string, conn conn.Conn, user, rootPath, rolePath string) Context {
 	return Context{
 		vars:     vars,
 		conn:     conn,
+		user:     user,
 		rootPath: rootPath,
 		rolePath: rolePath,
 	}
@@ -26,6 +27,7 @@ type Context struct {
 	conn     conn.Conn
 	vars     map[string]string
 	env      map[string]string
+	user     string
 	stdout   string
 	stderr   string
 	rolePath string
@@ -37,12 +39,17 @@ func (context *Context) Run(command Command) error {
 	cmd := conn.Command{
 		Interpreter: command.Interpreter,
 		Command:     command.Command,
-		User:        command.User,
+		User:        context.user,
 	}
 	response, err := context.conn.Run(cmd)
 	context.stdout = response.Stdout()
 	context.stderr = response.Stderr()
 	return err
+}
+
+// User specified to run command
+func (context Context) User() string {
+	return context.user
 }
 
 // Stdout retrieve the result of stdout sent by the last run

--- a/plugin/context_test.go
+++ b/plugin/context_test.go
@@ -10,7 +10,6 @@ func TestContextRun(t *testing.T) {
 	command := Command{
 		Interpreter: "bash",
 		Command:     []string{"pwd"},
-		User:        "root",
 	}
 	response := FakeResponse{
 		stdout: "stdout",
@@ -25,6 +24,7 @@ func TestContextRun(t *testing.T) {
 		vars: map[string]string{
 			"variable": "value",
 		},
+		user: "root",
 	}
 
 	context.Run(command)
@@ -37,7 +37,7 @@ func TestContextRun(t *testing.T) {
 	t.Run("passes the command to be ran on connection", func(t *testing.T) {
 		assert.Equal(t, fakeConn.command.Interpreter, command.Interpreter)
 		assert.Equal(t, fakeConn.command.Command, command.Command)
-		assert.Equal(t, fakeConn.command.User, command.User)
+		assert.Equal(t, fakeConn.command.User, context.User())
 		assert.Equal(t, fakeConn.command.Env, command.Env)
 	})
 	t.Run("get variables for task", func(t *testing.T) {

--- a/runner/run_task_test.go
+++ b/runner/run_task_test.go
@@ -52,6 +52,7 @@ func TestRunTask(t *testing.T) {
 			Type: "nil-task",
 			Name: "nil-task",
 			Attributes: map[string]*hcl.Attribute{
+				"user":             testExpression("user", "root"),
 				"static_value":     testExpression("static_value", "value"),
 				"dynamic_value":    testExpression("dynamic_value", "${ var.dynamic_value }"),
 				"other_task_value": testExpression("other_task_value", "${ previous_result.ok }"),
@@ -72,6 +73,7 @@ func TestRunTask(t *testing.T) {
 			assert.Equal(t, suppliedContext.Get("static_value"), "value")
 			assert.Equal(t, suppliedContext.Get("dynamic_value"), "dvalue")
 			assert.Equal(t, suppliedContext.Get("other_task_value"), "ok")
+			assert.Equal(t, suppliedContext.User(), "root")
 		})
 		t.Run("adds the new variables to the runners variables", func(t *testing.T) {
 			_, ok := runner.taskResults["nil-task"]


### PR DESCRIPTION
All tasks can now specify a user attribute which will set the user for
the running task.

Resolves #32 