### PR TITLE
User option for role for default user

### DIFF
--- a/azad/role.go
+++ b/azad/role.go
@@ -26,4 +26,5 @@ type Role struct {
 	Tasks      Tasks
 	Variables  map[string]cty.Value
 	Path       string
+	User       string
 }

--- a/parser/fixtures/basic.az
+++ b/parser/fixtures/basic.az
@@ -27,6 +27,8 @@ host "tag_kibana_server" {
 }
 
 role "elasticsearch" {
+  user = "root"
+
   variable "ruby_install_path" {
     default = "${var.install_path}/ruby"
   }

--- a/parser/parse_basic_playbook_test.go
+++ b/parser/parse_basic_playbook_test.go
@@ -58,6 +58,7 @@ func TestPlaybookFromFileBasic(t *testing.T) {
 
 			role := roles[0]
 			assert.Equal(t, role.Name, "elasticsearch")
+			assert.Equal(t, role.User, "root")
 			expect.EqualFatal(t, len(role.Variables), 1)
 			assert.Equal(t, role.Variables["ruby_install_path"].AsString(), "/opt/installer/ruby")
 

--- a/parser/role_description.go
+++ b/parser/role_description.go
@@ -72,6 +72,7 @@ type roleDescriptions []roleDescription
 type roleDescription struct {
 	Name       string                `hcl:",label"`
 	Dependents []string              `hcl:"dependents,optional"`
+	User       string                `hcl:"user,optional"`
 	Variables  []variableDescription `hcl:"variable,block"`
 	Config     hcl.Body              `hcl:",remain"`
 }

--- a/parser/unpack_roles.go
+++ b/parser/unpack_roles.go
@@ -58,6 +58,10 @@ func unpackTasksForRole(
 		return fmt.Errorf("cannot find main file for role %s", roleDescriptionGroup.name)
 	}
 	roleDescription := mainFile.roleDescription
+	user := roleDescription.User
+	if role.User == "" {
+		role.User = user
+	}
 	dependents := roleDescription.Dependents
 	variables, err := unpackVariables(roleDescription.Variables, roleContext)
 	if err != nil {

--- a/runner/run_playbook.go
+++ b/runner/run_playbook.go
@@ -42,14 +42,14 @@ var RunPlaybook = func(playbookFilePath string, globalConfig azad.Config) {
 			return
 		}
 		for _, role := range host.Roles {
-			runTasks(role.Tasks, runners.ChildRunners(role.Variables), role.Path, playbook.Path)
+			runTasks(role, runners.ChildRunners(role.Variables), playbook.Path)
 			logger.Info("Finished Applying %s", host.ServerGroup)
 		}
 	}
 }
 
-func runTasks(tasks azad.Tasks, runners runners, rootPath, rolePath string) error {
-	for _, task := range tasks {
+func runTasks(role azad.Role, runners runners, rootPath string) error {
+	for _, task := range role.Tasks {
 		taskSchema, _ := communicator.GetTask(task.PluginName(), task.TaskName())
 		for _, runner := range runners {
 			runTaskParams := runTaskParams{
@@ -57,7 +57,8 @@ func runTasks(tasks azad.Tasks, runners runners, rootPath, rolePath string) erro
 				taskSchema: taskSchema,
 				runner:     runner,
 				rootPath:   rootPath,
-				rolePath:   rolePath,
+				rolePath:   role.Path,
+				user:       role.User,
 			}
 			runTask(runTaskParams)
 		}

--- a/runner/run_task.go
+++ b/runner/run_task.go
@@ -18,6 +18,7 @@ type runTaskParams struct {
 	runner     *runner
 	rootPath   string
 	rolePath   string
+	user       string
 }
 
 func (runTaskParams runTaskParams) Type() string {
@@ -78,6 +79,9 @@ func runTask(runTaskParams runTaskParams) error {
 		}
 	}
 	userForTask := userForTask(runTaskParams.task, evalContext)
+	if userForTask == "" {
+		userForTask = runTaskParams.user
+	}
 	vars, err := varsForTask(runTaskParams.taskSchema.Fields, runTaskParams.task, evalContext)
 	if err != nil {
 		return err


### PR DESCRIPTION
Allow a role to define a user for that role. This can be useful if all
the tasks in a role require raised privileges access to install packages or
modify system files