### PR TITLE
Include multiple file in role

### DIFF
--- a/parser/fixtures/roles_per_folder/roles/ruby/install.az
+++ b/parser/fixtures/roles_per_folder/roles/ruby/install.az
@@ -1,0 +1,3 @@
+task "bash" "install gems" {
+  command = "apt-get install nginx"
+}

--- a/parser/fixtures/roles_per_folder/roles/ruby/main.az
+++ b/parser/fixtures/roles_per_folder/roles/ruby/main.az
@@ -8,10 +8,17 @@ task "apt-get.update" "update apt get" {
   user = "root"
 }
 
-include {
-  path = "dependencies"
+includes {
+  paths = ["dependencies"]
 }
 
 task "apt-get" "install ruby" {
   pgk = "libv8"
+}
+
+includes {
+  paths = [
+    "update",
+    "install",
+  ]
 }

--- a/parser/fixtures/roles_per_folder/roles/ruby/update.az
+++ b/parser/fixtures/roles_per_folder/roles/ruby/update.az
@@ -1,0 +1,3 @@
+task "apt-get" "install elasticsearch" {
+  pgk = "libv8"
+}

--- a/parser/load_config_test.go
+++ b/parser/load_config_test.go
@@ -23,10 +23,11 @@ func TestParseRoleConfig(t *testing.T) {
 	assert.Equal(t, roleDescription.Name, "main")
 	roleSchema := roleSchema()
 	content, err := roleDescription.Config.Content(&roleSchema)
-	if len(content.Blocks) != 3 {
+	if len(content.Blocks) != 4 {
 		t.Fatalf("expected 3 content blocks but got %d", len(content.Blocks))
 	}
 	assert.Equal(t, content.Blocks[0].Type, "task")
-	assert.Equal(t, content.Blocks[1].Type, "include")
+	assert.Equal(t, content.Blocks[1].Type, "includes")
 	assert.Equal(t, content.Blocks[2].Type, "task")
+	assert.Equal(t, content.Blocks[3].Type, "includes")
 }

--- a/parser/parse_roles_per_folder_test.go
+++ b/parser/parse_roles_per_folder_test.go
@@ -68,7 +68,20 @@ func TestParseRolesPerFolder(t *testing.T) {
 				rolePath := filepath.Join(filePath, "roles", "ruby")
 				assert.Equal(t, rubyRole.Path, rolePath)
 
-				assert.Equal(t, len(rubyRole.Tasks), 3)
+				assert.Equal(t, len(rubyRole.Tasks), 5)
+
+				taskNames := []string{}
+				for _, task := range rubyRole.Tasks {
+					taskNames = append(taskNames, task.Name)
+				}
+				expectedTaskNames := []string{
+					"update apt get",
+					"install nginx",
+					"install ruby",
+					"install elasticsearch",
+					"install gems",
+				}
+				assert.Equal(t, taskNames, expectedTaskNames)
 			})
 		})
 	})


### PR DESCRIPTION
It is common to require multiple files in a role. Previously with the
`include` task the would mean adding many repeating blocks.

`include` has now been replaced with `includes` which can take multiple
files making this far more concise

Resolves #39 