### PR TITLE
Add looping to tasks

### DIFF
--- a/example_playbooks/testing_playbook.az
+++ b/example_playbooks/testing_playbook.az
@@ -31,4 +31,22 @@ role "test_role" {
   task "bash" "write-secrets" {
     command = "echo '${ var.access["access_key"] }' >> ./${ var.output_file }"
   }
+
+  task "bash" "multiple-array" {
+    command = "echo '${ item }' >> ./${ var.output_file }"
+    debug = true
+    with-items = [
+      "val1",
+      "val2",
+    ]
+  }
+
+  task "bash" "multiple-with-map" {
+    command = "echo '${ item.a } + ${ item.b }' >> ./${ var.output_file }"
+    debug = true
+    with-items = [
+      { "a" = "1", "b" = "2" },
+      { "a" = "1", "b" = "2" },
+    ]
+  }
 }

--- a/parser/unpack_task.go
+++ b/parser/unpack_task.go
@@ -13,6 +13,7 @@ func unpackTask(block *hcl.Block) (steps.TaskStep, error) {
 		User:      content.Attributes["user"],
 		Condition: content.Attributes["condition"],
 		Debug:     content.Attributes["debug"],
+		WithItems: content.Attributes["with-items"],
 		Body:      body,
 	}, err
 }
@@ -23,6 +24,7 @@ func taskSchema() *hcl.BodySchema {
 			{Name: "user", Required: false},
 			{Name: "condition", Required: false},
 			{Name: "debug", Required: false},
+			{Name: "with-items", Required: false},
 		},
 	}
 }

--- a/runner/context_store_test.go
+++ b/runner/context_store_test.go
@@ -45,7 +45,8 @@ func assertExpressionForTask(
 	value string,
 ) {
 	expression := testExpression(name, variable)
-	evalContext, err := store.evalContextForTask(expression.Expr.Variables(), &connection)
+	additionalVariables := map[string]cty.Value{}
+	evalContext, err := store.evalContextForTask(expression.Expr.Variables(), &connection, additionalVariables)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/runner/store.go
+++ b/runner/store.go
@@ -36,7 +36,7 @@ type serverStore interface {
 
 type taskStore interface {
 	evalStore
-	evalVariableForTask(*hcl.Attribute, *connection, []string) (cty.Value, error)
+	evalVariableForTask(*hcl.Attribute, *connection, map[string]cty.Value, []string) (cty.Value, error)
 	connections() connections
 	user() string
 	playbookPath() string

--- a/steps/step.go
+++ b/steps/step.go
@@ -90,6 +90,7 @@ type TaskStep struct {
 	User      *hcl.Attribute
 	Condition *hcl.Attribute
 	Debug     *hcl.Attribute
+	WithItems *hcl.Attribute
 	Body      hcl.Body
 }
 


### PR DESCRIPTION
This introduces the `with-items` for tasks to allow looping tasks.
`with-items` must be a an array. The array can contain ether a map or
individual items.

The value of the item can be accessed via the `item` variable.